### PR TITLE
refactor: rename core crate to feedparser-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "feedparser-rs-core"
+name = "feedparser-rs"
 version = "0.1.0"
 dependencies = [
  "ammonia",
@@ -515,7 +515,7 @@ dependencies = [
 name = "feedparser-rs-node"
 version = "0.1.0"
 dependencies = [
- "feedparser-rs-core",
+ "feedparser-rs",
  "napi",
  "napi-build",
  "napi-derive",
@@ -526,7 +526,7 @@ name = "feedparser-rs-py"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "feedparser-rs-core",
+ "feedparser-rs",
  "pyo3",
 ]
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # feedparser-rs
 
-[![Crates.io](https://img.shields.io/crates/v/feedparser-rs-core)](https://crates.io/crates/feedparser-rs-core)
-[![docs.rs](https://img.shields.io/docsrs/feedparser-rs-core)](https://docs.rs/feedparser-rs-core)
+[![Crates.io](https://img.shields.io/crates/v/feedparser-rs)](https://crates.io/crates/feedparser-rs)
+[![docs.rs](https://img.shields.io/docsrs/feedparser-rs)](https://docs.rs/feedparser-rs)
 [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/feedparser-rs/ci.yml?branch=main)](https://github.com/bug-ops/feedparser-rs/actions)
 [![npm](https://img.shields.io/npm/v/feedparser-rs)](https://www.npmjs.com/package/feedparser-rs)
-[![License](https://img.shields.io/crates/l/feedparser-rs-core)](LICENSE-MIT)
+[![License](https://img.shields.io/crates/l/feedparser-rs)](LICENSE-MIT)
 
 High-performance RSS/Atom/JSON Feed parser for Rust, with Python and Node.js bindings. A drop-in replacement for Python's `feedparser` library with 10-100x performance improvement.
 
@@ -21,14 +21,14 @@ High-performance RSS/Atom/JSON Feed parser for Rust, with Python and Node.js bin
 ### Rust
 
 ```bash
-cargo add feedparser-rs-core
+cargo add feedparser-rs
 ```
 
 Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs-core = "0.1"
+feedparser-rs = "0.1"
 ```
 
 > [!IMPORTANT]
@@ -55,7 +55,7 @@ pip install feedparser-rs
 ### Rust Usage
 
 ```rust
-use feedparser_rs_core::parse;
+use feedparser_rs::parse;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let xml = r#"
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #### Fetching from URL
 
 ```rust
-use feedparser_rs_core::fetch_and_parse;
+use feedparser_rs::fetch_and_parse;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let feed = fetch_and_parse("https://example.com/feed.xml")?;
@@ -144,7 +144,7 @@ To disable HTTP support:
 
 ```toml
 [dependencies]
-feedparser-rs-core = { version = "0.1", default-features = false }
+feedparser-rs = { version = "0.1", default-features = false }
 ```
 
 ## Workspace Structure
@@ -153,7 +153,7 @@ This repository contains multiple crates:
 
 | Crate | Description | Package |
 |-------|-------------|---------|
-| [`feedparser-rs-core`](crates/feedparser-rs-core) | Core Rust parser | [crates.io](https://crates.io/crates/feedparser-rs-core) |
+| [`feedparser-rs`](crates/feedparser-rs) | Core Rust parser | [crates.io](https://crates.io/crates/feedparser-rs) |
 | [`feedparser-rs-node`](crates/feedparser-rs-node) | Node.js bindings | [npm](https://www.npmjs.com/package/feedparser-rs) |
 | [`feedparser-rs-py`](crates/feedparser-rs-py) | Python bindings | [PyPI](https://pypi.org/project/feedparser-rs) |
 

--- a/crates/feedparser-rs-core/Cargo.toml
+++ b/crates/feedparser-rs-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "feedparser-rs-core"
+name = "feedparser-rs"
 description = "High-performance RSS/Atom/JSON Feed parser"
 readme = "README.md"
 version.workspace = true

--- a/crates/feedparser-rs-core/README.md
+++ b/crates/feedparser-rs-core/README.md
@@ -1,4 +1,4 @@
-# feedparser-rs-core
+# feedparser-rs
 
 High-performance RSS/Atom/JSON Feed parser written in Rust.
 
@@ -18,13 +18,13 @@ This is the core parsing library that powers the Python and Node.js bindings.
 
 ```toml
 [dependencies]
-feedparser-rs-core = "0.1"
+feedparser-rs = "0.1"
 ```
 
 ## Quick Start
 
 ```rust
-use feedparser_rs_core::parse;
+use feedparser_rs::parse;
 
 let xml = r#"
     <?xml version="1.0"?>
@@ -42,7 +42,7 @@ let xml = r#"
 let feed = parse(xml.as_bytes())?;
 assert_eq!(feed.feed.title.as_deref(), Some("My Blog"));
 assert_eq!(feed.entries.len(), 1);
-# Ok::<(), feedparser_rs_core::FeedError>(())
+# Ok::<(), feedparser_rs::FeedError>(())
 ```
 
 ## HTTP Fetching
@@ -50,7 +50,7 @@ assert_eq!(feed.entries.len(), 1);
 Fetch feeds directly from URLs with automatic compression handling:
 
 ```rust
-use feedparser_rs_core::parse_url;
+use feedparser_rs::parse_url;
 
 let feed = parse_url("https://example.com/feed.xml", None, None, None)?;
 println!("Title: {:?}", feed.feed.title);
@@ -67,14 +67,14 @@ let feed2 = parse_url(
 if feed2.status == Some(304) {
     println!("Not modified, use cached version");
 }
-# Ok::<(), feedparser_rs_core::FeedError>(())
+# Ok::<(), feedparser_rs::FeedError>(())
 ```
 
 To disable HTTP support and reduce dependencies:
 
 ```toml
 [dependencies]
-feedparser-rs-core = { version = "0.1", default-features = false }
+feedparser-rs = { version = "0.1", default-features = false }
 ```
 
 ## Platform Bindings
@@ -96,14 +96,14 @@ See [benchmarks/](../../benchmarks/) for detailed benchmark code.
 
 ## API Documentation
 
-For full API documentation, see [docs.rs/feedparser-rs-core](https://docs.rs/feedparser-rs-core).
+For full API documentation, see [docs.rs/feedparser-rs](https://docs.rs/feedparser-rs).
 
 ## Error Handling
 
 The library uses a "bozo" flag (like feedparser) to indicate parsing errors while still returning partial results:
 
 ```rust
-use feedparser_rs_core::parse;
+use feedparser_rs::parse;
 
 let malformed = b"<rss><channel><title>Broken</title></rss>";
 let feed = parse(malformed)?;
@@ -112,7 +112,7 @@ assert!(feed.bozo);
 assert!(feed.bozo_exception.is_some());
 // Still can access parsed data
 assert_eq!(feed.feed.title.as_deref(), Some("Broken"));
-# Ok::<(), feedparser_rs_core::FeedError>(())
+# Ok::<(), feedparser_rs::FeedError>(())
 ```
 
 ## Parser Limits
@@ -120,7 +120,7 @@ assert_eq!(feed.feed.title.as_deref(), Some("Broken"));
 To prevent resource exhaustion, the parser enforces limits:
 
 ```rust
-use feedparser_rs_core::{parse_with_limits, ParserLimits};
+use feedparser_rs::{parse_with_limits, ParserLimits};
 
 let limits = ParserLimits {
     max_entries: 100,
@@ -129,7 +129,7 @@ let limits = ParserLimits {
 };
 
 let feed = parse_with_limits(xml.as_bytes(), limits)?;
-# Ok::<(), feedparser_rs_core::FeedError>(())
+# Ok::<(), feedparser_rs::FeedError>(())
 ```
 
 ## License
@@ -139,5 +139,5 @@ MIT OR Apache-2.0
 ## Links
 
 - [GitHub](https://github.com/bug-ops/feedparser-rs)
-- [Documentation](https://docs.rs/feedparser-rs-core)
+- [Documentation](https://docs.rs/feedparser-rs)
 - [Changelog](../../CHANGELOG.md)

--- a/crates/feedparser-rs-core/benches/parsing.rs
+++ b/crates/feedparser-rs-core/benches/parsing.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use feedparser_rs_core::parse;
+use feedparser_rs::parse;
 use std::hint::black_box;
 
 const SMALL_FEED: &[u8] = include_bytes!("../../../benchmarks/fixtures/small.xml");
@@ -29,7 +29,7 @@ fn bench_parse_feeds(c: &mut Criterion) {
 }
 
 fn bench_detect_format(c: &mut Criterion) {
-    use feedparser_rs_core::detect_format;
+    use feedparser_rs::detect_format;
 
     let mut group = c.benchmark_group("detect_format");
 

--- a/crates/feedparser-rs-core/src/http/mod.rs
+++ b/crates/feedparser-rs-core/src/http/mod.rs
@@ -9,7 +9,7 @@
 /// # Examples
 ///
 /// ```no_run
-/// use feedparser_rs_core::http::FeedHttpClient;
+/// use feedparser_rs::http::FeedHttpClient;
 ///
 /// let client = FeedHttpClient::new().unwrap();
 /// let response = client.get(

--- a/crates/feedparser-rs-core/src/http/validation.rs
+++ b/crates/feedparser-rs-core/src/http/validation.rs
@@ -54,7 +54,7 @@ const METADATA_DOMAINS: &[&str] = &[
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::http::validation::validate_url;
+/// use feedparser_rs::http::validation::validate_url;
 ///
 /// // These are allowed
 /// assert!(validate_url("https://example.com/feed.xml").is_ok());

--- a/crates/feedparser-rs-core/src/lib.rs
+++ b/crates/feedparser-rs-core/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Examples
 //!
 //! ```
-//! use feedparser_rs_core::parse;
+//! use feedparser_rs::parse;
 //!
 //! let xml = r#"
 //!     <?xml version="1.0"?>
@@ -106,7 +106,7 @@ pub use http::{FeedHttpClient, FeedHttpResponse};
 /// # Examples
 ///
 /// ```no_run
-/// use feedparser_rs_core::parse_url;
+/// use feedparser_rs::parse_url;
 ///
 /// // First fetch
 /// let feed = parse_url("https://example.com/feed.xml", None, None, None).unwrap();
@@ -196,7 +196,7 @@ pub fn parse_url(
 /// # Examples
 ///
 /// ```no_run
-/// use feedparser_rs_core::{parse_url_with_limits, ParserLimits};
+/// use feedparser_rs::{parse_url_with_limits, ParserLimits};
 ///
 /// let limits = ParserLimits::strict();
 /// let feed = parse_url_with_limits(

--- a/crates/feedparser-rs-core/src/limits.rs
+++ b/crates/feedparser-rs-core/src/limits.rs
@@ -8,7 +8,7 @@
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::ParserLimits;
+/// use feedparser_rs::ParserLimits;
 ///
 /// let limits = ParserLimits::default();
 /// assert_eq!(limits.max_entries, 10_000);
@@ -142,7 +142,7 @@ impl ParserLimits {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::ParserLimits;
+    /// use feedparser_rs::ParserLimits;
     ///
     /// let limits = ParserLimits::strict();
     /// assert_eq!(limits.max_entries, 1_000);
@@ -174,7 +174,7 @@ impl ParserLimits {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::ParserLimits;
+    /// use feedparser_rs::ParserLimits;
     ///
     /// let limits = ParserLimits::permissive();
     /// assert_eq!(limits.max_entries, 100_000);

--- a/crates/feedparser-rs-core/src/namespace/mod.rs
+++ b/crates/feedparser-rs-core/src/namespace/mod.rs
@@ -16,8 +16,8 @@
 /// # Example
 ///
 /// ```
-/// use feedparser_rs_core::namespace::dublin_core;
-/// use feedparser_rs_core::FeedMeta;
+/// use feedparser_rs::namespace::dublin_core;
+/// use feedparser_rs::FeedMeta;
 ///
 /// let mut feed = FeedMeta::default();
 /// dublin_core::handle_feed_element("creator", "John Doe", &mut feed);

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -32,7 +32,7 @@ pub const TEXT_BUFFER_CAPACITY: usize = 256;
 /// # Examples
 ///
 /// ```ignore
-/// use feedparser_rs_core::parser::common::new_event_buffer;
+/// use feedparser_rs::parser::common::new_event_buffer;
 ///
 /// let mut buf = new_event_buffer();
 /// assert!(buf.capacity() >= 1024);
@@ -57,7 +57,7 @@ pub fn new_event_buffer() -> Vec<u8> {
 /// # Examples
 ///
 /// ```ignore
-/// use feedparser_rs_core::parser::common::new_text_buffer;
+/// use feedparser_rs::parser::common::new_text_buffer;
 ///
 /// let mut text = new_text_buffer();
 /// assert!(text.capacity() >= 256);

--- a/crates/feedparser-rs-core/src/parser/detect.rs
+++ b/crates/feedparser-rs-core/src/parser/detect.rs
@@ -24,7 +24,7 @@ const MAX_JSON_DETECTION_SIZE: usize = 1024 * 1024; // 1MB
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::{detect_format, FeedVersion};
+/// use feedparser_rs::{detect_format, FeedVersion};
 ///
 /// let rss = br#"<?xml version="1.0"?><rss version="2.0"></rss>"#;
 /// assert_eq!(detect_format(rss), FeedVersion::Rss20);

--- a/crates/feedparser-rs-core/src/parser/mod.rs
+++ b/crates/feedparser-rs-core/src/parser/mod.rs
@@ -24,7 +24,7 @@ pub use detect::detect_format;
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::parse;
+/// use feedparser_rs::parse;
 ///
 /// let xml = r#"
 ///     <?xml version="1.0"?>
@@ -49,7 +49,7 @@ pub fn parse(data: &[u8]) -> Result<ParsedFeed> {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::{parse_with_limits, ParserLimits};
+/// use feedparser_rs::{parse_with_limits, ParserLimits};
 ///
 /// let xml = b"<rss version=\"2.0\"><channel><title>Test</title></channel></rss>";
 /// let limits = ParserLimits::strict();

--- a/crates/feedparser-rs-core/src/parser/namespace_detection.rs
+++ b/crates/feedparser-rs-core/src/parser/namespace_detection.rs
@@ -7,7 +7,7 @@
 //! # Examples
 //!
 //! ```ignore
-//! use feedparser_rs_core::parser::namespace_detection::namespaces;
+//! use feedparser_rs::parser::namespace_detection::namespaces;
 //!
 //! let tag_name = b"dc:creator";
 //! if let Some(element) = namespaces::DC.matches(tag_name) {
@@ -33,7 +33,7 @@ impl NamespacePrefix {
     /// # Examples
     ///
     /// ```ignore
-    /// use feedparser_rs_core::parser::namespace_detection::NamespacePrefix;
+    /// use feedparser_rs::parser::namespace_detection::NamespacePrefix;
     ///
     /// const CUSTOM: NamespacePrefix = NamespacePrefix::new("custom:");
     /// ```
@@ -64,7 +64,7 @@ impl NamespacePrefix {
     /// # Examples
     ///
     /// ```ignore
-    /// use feedparser_rs_core::parser::namespace_detection::namespaces;
+    /// use feedparser_rs::parser::namespace_detection::namespaces;
     ///
     /// assert_eq!(namespaces::DC.matches(b"dc:creator"), Some("creator"));
     /// assert_eq!(namespaces::DC.matches(b"content:encoded"), None);
@@ -96,7 +96,7 @@ impl NamespacePrefix {
     /// # Examples
     ///
     /// ```ignore
-    /// use feedparser_rs_core::parser::namespace_detection::namespaces;
+    /// use feedparser_rs::parser::namespace_detection::namespaces;
     ///
     /// assert_eq!(namespaces::DC.prefix(), "dc:");
     /// ```
@@ -130,7 +130,7 @@ impl NamespacePrefix {
 /// # Examples
 ///
 /// ```ignore
-/// use feedparser_rs_core::parser::namespace_detection::namespaces;
+/// use feedparser_rs::parser::namespace_detection::namespaces;
 ///
 /// let tag = b"itunes:author";
 /// if let Some(element) = namespaces::ITUNES.matches(tag) {

--- a/crates/feedparser-rs-core/src/types/common.rs
+++ b/crates/feedparser-rs-core/src/types/common.rs
@@ -97,7 +97,7 @@ impl Person {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::types::Person;
+    /// use feedparser_rs::types::Person;
     ///
     /// let person = Person::from_name("John Doe");
     /// assert_eq!(person.name.as_deref(), Some("John Doe"));

--- a/crates/feedparser-rs-core/src/types/entry.rs
+++ b/crates/feedparser-rs-core/src/types/entry.rs
@@ -88,7 +88,7 @@ impl Entry {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::Entry;
+    /// use feedparser_rs::Entry;
     ///
     /// let entry = Entry::with_capacity();
     /// ```
@@ -115,7 +115,7 @@ impl Entry {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{Entry, TextConstruct};
+    /// use feedparser_rs::{Entry, TextConstruct};
     ///
     /// let mut entry = Entry::default();
     /// entry.set_title(TextConstruct::text("Great Article"));
@@ -132,7 +132,7 @@ impl Entry {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{Entry, TextConstruct};
+    /// use feedparser_rs::{Entry, TextConstruct};
     ///
     /// let mut entry = Entry::default();
     /// entry.set_summary(TextConstruct::text("A summary"));
@@ -149,7 +149,7 @@ impl Entry {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{Entry, Person};
+    /// use feedparser_rs::{Entry, Person};
     ///
     /// let mut entry = Entry::default();
     /// entry.set_author(Person::from_name("Jane Doe"));
@@ -166,7 +166,7 @@ impl Entry {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{Entry, Person};
+    /// use feedparser_rs::{Entry, Person};
     ///
     /// let mut entry = Entry::default();
     /// entry.set_publisher(Person::from_name("ACME Corp"));

--- a/crates/feedparser-rs-core/src/types/feed.rs
+++ b/crates/feedparser-rs-core/src/types/feed.rs
@@ -128,7 +128,7 @@ impl ParsedFeed {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::ParsedFeed;
+    /// use feedparser_rs::ParsedFeed;
     ///
     /// let feed = ParsedFeed::with_capacity(50);
     /// assert_eq!(feed.encoding, "utf-8");
@@ -212,7 +212,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::FeedMeta;
+    /// use feedparser_rs::FeedMeta;
     ///
     /// let meta = FeedMeta::with_rss_capacity();
     /// ```
@@ -238,7 +238,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::FeedMeta;
+    /// use feedparser_rs::FeedMeta;
     ///
     /// let meta = FeedMeta::with_atom_capacity();
     /// ```
@@ -258,7 +258,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{FeedMeta, TextConstruct};
+    /// use feedparser_rs::{FeedMeta, TextConstruct};
     ///
     /// let mut meta = FeedMeta::default();
     /// meta.set_title(TextConstruct::text("Example Feed"));
@@ -275,7 +275,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{FeedMeta, TextConstruct};
+    /// use feedparser_rs::{FeedMeta, TextConstruct};
     ///
     /// let mut meta = FeedMeta::default();
     /// meta.set_subtitle(TextConstruct::text("A great feed"));
@@ -292,7 +292,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{FeedMeta, TextConstruct};
+    /// use feedparser_rs::{FeedMeta, TextConstruct};
     ///
     /// let mut meta = FeedMeta::default();
     /// meta.set_rights(TextConstruct::text("© 2025 Example"));
@@ -309,7 +309,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{FeedMeta, Generator};
+    /// use feedparser_rs::{FeedMeta, Generator};
     ///
     /// # fn main() {
     /// let mut meta = FeedMeta::default();
@@ -333,7 +333,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{FeedMeta, Person};
+    /// use feedparser_rs::{FeedMeta, Person};
     ///
     /// let mut meta = FeedMeta::default();
     /// meta.set_author(Person::from_name("John Doe"));
@@ -350,7 +350,7 @@ impl FeedMeta {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::{FeedMeta, Person};
+    /// use feedparser_rs::{FeedMeta, Person};
     ///
     /// let mut meta = FeedMeta::default();
     /// meta.set_publisher(Person::from_name("ACME Corp"));

--- a/crates/feedparser-rs-core/src/types/generics.rs
+++ b/crates/feedparser-rs-core/src/types/generics.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::types::generics::DetailedField;
+/// use feedparser_rs::types::generics::DetailedField;
 ///
 /// // Simple value only
 /// let title: DetailedField<String, ()> = DetailedField::from_value("My Title".to_string());
@@ -135,7 +135,7 @@ impl<V, D> From<(V, D)> for DetailedField<V, D> {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::types::LimitedCollectionExt;
+/// use feedparser_rs::types::LimitedCollectionExt;
 ///
 /// let mut vec = Vec::new();
 /// assert!(vec.try_push_limited("first", 2));
@@ -209,8 +209,8 @@ pub trait FromAttributes: Sized {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::types::generics::ParseFrom;
-/// use feedparser_rs_core::types::Person;
+/// use feedparser_rs::types::generics::ParseFrom;
+/// use feedparser_rs::types::Person;
 /// use serde_json::json;
 ///
 /// let json = json!({"name": "John Doe", "url": "https://example.com"});

--- a/crates/feedparser-rs-core/src/types/podcast.rs
+++ b/crates/feedparser-rs-core/src/types/podcast.rs
@@ -6,7 +6,7 @@
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::ItunesFeedMeta;
+/// use feedparser_rs::ItunesFeedMeta;
 ///
 /// let mut itunes = ItunesFeedMeta::default();
 /// itunes.author = Some("John Doe".to_string());
@@ -40,7 +40,7 @@ pub struct ItunesFeedMeta {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::ItunesEntryMeta;
+/// use feedparser_rs::ItunesEntryMeta;
 ///
 /// let mut episode = ItunesEntryMeta::default();
 /// episode.duration = Some(3600); // 1 hour
@@ -79,7 +79,7 @@ pub struct ItunesEntryMeta {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::ItunesOwner;
+/// use feedparser_rs::ItunesOwner;
 ///
 /// let owner = ItunesOwner {
 ///     name: Some("Jane Doe".to_string()),
@@ -103,7 +103,7 @@ pub struct ItunesOwner {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::ItunesCategory;
+/// use feedparser_rs::ItunesCategory;
 ///
 /// let category = ItunesCategory {
 ///     text: "Technology".to_string(),
@@ -127,7 +127,7 @@ pub struct ItunesCategory {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::PodcastMeta;
+/// use feedparser_rs::PodcastMeta;
 ///
 /// let mut podcast = PodcastMeta::default();
 /// podcast.guid = Some("9b024349-ccf0-5f69-a609-6b82873eab3c".to_string());
@@ -153,7 +153,7 @@ pub struct PodcastMeta {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::PodcastTranscript;
+/// use feedparser_rs::PodcastTranscript;
 ///
 /// let transcript = PodcastTranscript {
 ///     url: "https://example.com/transcript.txt".to_string(),
@@ -183,7 +183,7 @@ pub struct PodcastTranscript {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::PodcastFunding;
+/// use feedparser_rs::PodcastFunding;
 ///
 /// let funding = PodcastFunding {
 ///     url: "https://example.com/donate".to_string(),
@@ -207,7 +207,7 @@ pub struct PodcastFunding {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::PodcastPerson;
+/// use feedparser_rs::PodcastPerson;
 ///
 /// let host = PodcastPerson {
 ///     name: "John Doe".to_string(),
@@ -248,7 +248,7 @@ pub struct PodcastPerson {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::parse_duration;
+/// use feedparser_rs::parse_duration;
 ///
 /// assert_eq!(parse_duration("3600"), Some(3600));
 /// assert_eq!(parse_duration("60:30"), Some(3630));
@@ -301,7 +301,7 @@ pub fn parse_duration(s: &str) -> Option<u32> {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::parse_explicit;
+/// use feedparser_rs::parse_explicit;
 ///
 /// assert_eq!(parse_explicit("yes"), Some(true));
 /// assert_eq!(parse_explicit("YES"), Some(true));

--- a/crates/feedparser-rs-core/src/types/version.rs
+++ b/crates/feedparser-rs-core/src/types/version.rs
@@ -32,7 +32,7 @@ impl FeedVersion {
     /// # Examples
     ///
     /// ```
-    /// use feedparser_rs_core::FeedVersion;
+    /// use feedparser_rs::FeedVersion;
     ///
     /// assert_eq!(FeedVersion::Rss20.as_str(), "rss20");
     /// assert_eq!(FeedVersion::Atom10.as_str(), "atom10");

--- a/crates/feedparser-rs-core/src/util/date.rs
+++ b/crates/feedparser-rs-core/src/util/date.rs
@@ -59,7 +59,7 @@ const DATE_FORMATS: &[&str] = &[
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::date::parse_date;
+/// use feedparser_rs::util::date::parse_date;
 ///
 /// // RFC 3339 (Atom)
 /// assert!(parse_date("2024-12-14T10:30:00Z").is_some());

--- a/crates/feedparser-rs-core/src/util/encoding.rs
+++ b/crates/feedparser-rs-core/src/util/encoding.rs
@@ -23,7 +23,7 @@ use encoding_rs::{Encoding, UTF_8};
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::encoding::detect_encoding;
+/// use feedparser_rs::util::encoding::detect_encoding;
 ///
 /// // UTF-8 with BOM
 /// let data = b"\xEF\xBB\xBF<?xml version=\"1.0\"?>";
@@ -102,7 +102,7 @@ fn normalize_encoding_name(name: &str) -> Option<&'static str> {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::encoding::convert_to_utf8;
+/// use feedparser_rs::util::encoding::convert_to_utf8;
 ///
 /// let latin1 = b"\xE9"; // é in ISO-8859-1
 /// let utf8 = convert_to_utf8(latin1, "iso-8859-1").unwrap();
@@ -132,7 +132,7 @@ pub fn convert_to_utf8(data: &[u8], encoding_name: &str) -> Result<String, Strin
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::encoding::detect_and_convert;
+/// use feedparser_rs::util::encoding::detect_and_convert;
 ///
 /// let data = b"<?xml version=\"1.0\"?><root>Test</root>";
 /// let (utf8, detected_encoding) = detect_and_convert(data).unwrap();

--- a/crates/feedparser-rs-core/src/util/sanitize.rs
+++ b/crates/feedparser-rs-core/src/util/sanitize.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::sanitize::sanitize_html;
+/// use feedparser_rs::util::sanitize::sanitize_html;
 ///
 /// let unsafe_html = r#"<p>Hello</p><script>alert('XSS')</script>"#;
 /// let safe_html = sanitize_html(unsafe_html);
@@ -112,7 +112,7 @@ pub fn sanitize_html(input: &str) -> String {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::sanitize::decode_entities;
+/// use feedparser_rs::util::sanitize::decode_entities;
 ///
 /// assert_eq!(decode_entities("&lt;p&gt;Hello&lt;/p&gt;"), "<p>Hello</p>");
 /// assert_eq!(decode_entities("&amp;amp;"), "&amp;");
@@ -130,7 +130,7 @@ pub fn decode_entities(input: &str) -> String {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::sanitize::sanitize_and_decode;
+/// use feedparser_rs::util::sanitize::sanitize_and_decode;
 ///
 /// let input = "&lt;p&gt;Safe&lt;/p&gt;&lt;script&gt;alert('XSS')&lt;/script&gt;";
 /// let output = sanitize_and_decode(input);
@@ -146,7 +146,7 @@ pub fn sanitize_and_decode(input: &str) -> String {
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::sanitize::strip_tags;
+/// use feedparser_rs::util::sanitize::strip_tags;
 ///
 /// assert_eq!(strip_tags("<p>Hello <b>world</b></p>"), "Hello world");
 /// ```

--- a/crates/feedparser-rs-core/src/util/text.rs
+++ b/crates/feedparser-rs-core/src/util/text.rs
@@ -11,7 +11,7 @@
 /// # Examples
 ///
 /// ```
-/// use feedparser_rs_core::util::text::bytes_to_string;
+/// use feedparser_rs::util::text::bytes_to_string;
 ///
 /// let valid_utf8 = b"Hello, world!";
 /// assert_eq!(bytes_to_string(valid_utf8), "Hello, world!");

--- a/crates/feedparser-rs-core/tests/http_integration.rs
+++ b/crates/feedparser-rs-core/tests/http_integration.rs
@@ -3,8 +3,8 @@
 #[cfg(feature = "http")]
 #[allow(clippy::significant_drop_tightening)]
 mod http_tests {
-    use feedparser_rs_core::FeedError;
-    use feedparser_rs_core::http::{FeedHttpClient, FeedHttpResponse};
+    use feedparser_rs::FeedError;
+    use feedparser_rs::http::{FeedHttpClient, FeedHttpResponse};
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use reqwest::blocking::Client;

--- a/crates/feedparser-rs-core/tests/integration_tests.rs
+++ b/crates/feedparser-rs-core/tests/integration_tests.rs
@@ -4,7 +4,7 @@
     clippy::single_match_else
 )]
 
-use feedparser_rs_core::{FeedVersion, detect_format, parse};
+use feedparser_rs::{FeedVersion, detect_format, parse};
 
 /// Helper function to load test fixtures
 fn load_fixture(path: &str) -> Vec<u8> {
@@ -15,7 +15,7 @@ fn load_fixture(path: &str) -> Vec<u8> {
 }
 
 /// Helper to assert basic feed validity
-fn assert_feed_valid(result: &feedparser_rs_core::ParsedFeed) {
+fn assert_feed_valid(result: &feedparser_rs::ParsedFeed) {
     // Currently stubs return empty feeds, so we just check it doesn't panic
     // Phase 2: Add real assertions here
     assert!(result.version == FeedVersion::Unknown || !result.bozo);
@@ -113,7 +113,7 @@ fn test_parse_invalid_xml() {
 
 #[test]
 fn test_capacity_constructors() {
-    use feedparser_rs_core::{Entry, FeedMeta, ParsedFeed};
+    use feedparser_rs::{Entry, FeedMeta, ParsedFeed};
 
     // Test ParsedFeed::with_capacity
     let feed = ParsedFeed::with_capacity(100);

--- a/crates/feedparser-rs-core/tests/namespace_edge_cases.rs
+++ b/crates/feedparser-rs-core/tests/namespace_edge_cases.rs
@@ -3,7 +3,7 @@
 //! This module tests edge cases and error conditions for Dublin Core,
 //! Content, and Media RSS namespace parsing.
 
-use feedparser_rs_core::parse;
+use feedparser_rs::parse;
 
 /// Tests namespace URI handling
 ///

--- a/crates/feedparser-rs-core/tests/namespace_integration.rs
+++ b/crates/feedparser-rs-core/tests/namespace_integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests for namespace parsing (Dublin Core, Content, Media RSS)
 
-use feedparser_rs_core::parse;
+use feedparser_rs::parse;
 
 #[test]
 fn test_rss_with_dublin_core() {

--- a/crates/feedparser-rs-node/Cargo.toml
+++ b/crates/feedparser-rs-node/Cargo.toml
@@ -13,13 +13,13 @@ description = "Node.js bindings for feedparser-rs-core"
 crate-type = ["cdylib"]
 
 [dependencies]
-feedparser-rs-core = { path = "../feedparser-rs-core" }
+feedparser-rs = { path = "../feedparser-rs-core" }
 napi = { workspace = true, features = ["napi9", "error_anyhow"] }
 napi-derive = { workspace = true }
 
 [features]
 default = ["http"]
-http = ["feedparser-rs-core/http"]
+http = ["feedparser-rs/http"]
 
 [build-dependencies]
 napi-build = "2.1"

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -4,7 +4,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use std::collections::HashMap;
 
-use feedparser_rs_core::{
+use feedparser_rs::{
     self as core, Content as CoreContent, Enclosure as CoreEnclosure, Entry as CoreEntry,
     FeedMeta as CoreFeedMeta, Generator as CoreGenerator, Image as CoreImage, Link as CoreLink,
     ParsedFeed as CoreParsedFeed, ParserLimits, Person as CorePerson,

--- a/crates/feedparser-rs-py/Cargo.toml
+++ b/crates/feedparser-rs-py/Cargo.toml
@@ -15,10 +15,10 @@ name = "feedparser_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-feedparser-rs-core = { path = "../feedparser-rs-core" }
+feedparser-rs = { path = "../feedparser-rs-core" }
 pyo3 = { workspace = true, features = ["extension-module", "chrono"] }
 chrono = { workspace = true, features = ["clock"] }
 
 [features]
 default = ["http"]
-http = ["feedparser-rs-core/http"]
+http = ["feedparser-rs/http"]

--- a/crates/feedparser-rs-py/src/error.rs
+++ b/crates/feedparser-rs-py/src/error.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::FeedError;
+use feedparser_rs::FeedError;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 

--- a/crates/feedparser-rs-py/src/lib.rs
+++ b/crates/feedparser-rs-py/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
-use feedparser_rs_core as core;
+use feedparser_rs as core;
 
 mod error;
 mod limits;

--- a/crates/feedparser-rs-py/src/limits.rs
+++ b/crates/feedparser-rs-py/src/limits.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::ParserLimits as CoreParserLimits;
+use feedparser_rs::ParserLimits as CoreParserLimits;
 use pyo3::prelude::*;
 
 /// Resource limits for feed parsing (DoS protection)

--- a/crates/feedparser-rs-py/src/types/common.rs
+++ b/crates/feedparser-rs-py/src/types/common.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::{
+use feedparser_rs::{
     Content as CoreContent, Enclosure as CoreEnclosure, Generator as CoreGenerator,
     Image as CoreImage, Link as CoreLink, Person as CorePerson, Source as CoreSource,
     Tag as CoreTag, TextConstruct as CoreTextConstruct, TextType,

--- a/crates/feedparser-rs-py/src/types/entry.rs
+++ b/crates/feedparser-rs-py/src/types/entry.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::Entry as CoreEntry;
+use feedparser_rs::Entry as CoreEntry;
 use pyo3::prelude::*;
 
 use super::common::{PyContent, PyEnclosure, PyLink, PyPerson, PySource, PyTag, PyTextConstruct};

--- a/crates/feedparser-rs-py/src/types/feed_meta.rs
+++ b/crates/feedparser-rs-py/src/types/feed_meta.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::FeedMeta as CoreFeedMeta;
+use feedparser_rs::FeedMeta as CoreFeedMeta;
 use pyo3::prelude::*;
 
 use super::common::{PyGenerator, PyImage, PyLink, PyPerson, PyTag, PyTextConstruct};

--- a/crates/feedparser-rs-py/src/types/parsed_feed.rs
+++ b/crates/feedparser-rs-py/src/types/parsed_feed.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::ParsedFeed as CoreParsedFeed;
+use feedparser_rs::ParsedFeed as CoreParsedFeed;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 

--- a/crates/feedparser-rs-py/src/types/podcast.rs
+++ b/crates/feedparser-rs-py/src/types/podcast.rs
@@ -1,4 +1,4 @@
-use feedparser_rs_core::{
+use feedparser_rs::{
     ItunesCategory as CoreItunesCategory, ItunesEntryMeta as CoreItunesEntryMeta,
     ItunesFeedMeta as CoreItunesFeedMeta, ItunesOwner as CoreItunesOwner,
     PodcastFunding as CorePodcastFunding, PodcastMeta as CorePodcastMeta,


### PR DESCRIPTION
## Summary

Simplify the crate name for crates.io publication by renaming from `feedparser-rs-core` to `feedparser-rs`.

## Changes

- Rename package name in `Cargo.toml` from `feedparser-rs-core` to `feedparser-rs`
- Update all internal dependencies in py and node crates
- Update all imports from `feedparser_rs_core` to `feedparser_rs`
- Update documentation references in README files

The directory structure remains unchanged (`crates/feedparser-rs-core/`) to maintain git history and minimize disruption.

## Benefits

- Simpler crate name: `feedparser-rs` instead of `feedparser-rs-core`
- Enables publishing with `cargo publish --workspace`
- Users can now simply `cargo add feedparser-rs`

## Test plan

- [x] `cargo build -p feedparser-rs -p feedparser-rs-node` succeeds
- [x] `cargo test -p feedparser-rs` passes (50 tests)
- [x] `cargo publish --workspace --dry-run` succeeds