### PR TITLE
chore: bump Python and Node.js manifest versions to 0.4.1

### DIFF
--- a/crates/feedparser-rs-node/package.json
+++ b/crates/feedparser-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedparser-rs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "High-performance RSS/Atom/JSON Feed parser for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/feedparser-rs-py/pyproject.toml
+++ b/crates/feedparser-rs-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feedparser-rs"
-version = "0.4.0"
+version = "0.4.1"
 description = "High-performance RSS/Atom/JSON Feed parser with feedparser-compatible API"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

- Update `pyproject.toml` version to 0.4.1
- Update `package.json` version to 0.4.1

Missed in #43.