### PR TITLE
ci: add CodeQL advanced setup for PR analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 1 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+
+      - run: cargo build --workspace
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"


### PR DESCRIPTION
## Summary

- Replace default CodeQL setup with custom workflow triggering on `push`, `pull_request`, and weekly schedule
- Enables security analysis for external fork PRs (previously skipped)

## Manual step after merge

Disable default CodeQL setup in **Settings > Code security > Code scanning** to avoid duplicate runs.

Closes #65