### PR TITLE
ci: make release workflow idempotent for re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,11 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish to crates.io
-        run: cargo publish -p feedparser-rs
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        uses: katyo/publish-crates@v2
+        with:
+          path: crates/feedparser-rs-core
+          registry-token: ${{ steps.auth.outputs.token }}
+          ignore-unpublished-changes: true
 
   # ============================================================================
   # PYPI
@@ -170,7 +172,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          skip-existing: false
+          skip-existing: true
           verbose: true
 
   # ============================================================================
@@ -265,7 +267,13 @@ jobs:
         working-directory: crates/feedparser-rs-node
         run: |
           echo "npm version: $(npm --version)"
-          npm publish --access public --ignore-scripts
+          npm publish --access public --ignore-scripts 2>&1 | tee /tmp/npm-publish.log || {
+            if grep -q "cannot publish over the previously published versions" /tmp/npm-publish.log; then
+              echo "Version already published, skipping"
+            else
+              exit 1
+            fi
+          }
 
   # ============================================================================
   # GITHUB RELEASE


### PR DESCRIPTION
## Summary

- Switch crates.io publish to `katyo/publish-crates@v2` with `ignore-unpublished-changes: true`
- Enable `skip-existing: true` for PyPI publish via `pypa/gh-action-pypi-publish`
- Handle npm "already published" error gracefully, failing only on unexpected errors

Allows safe re-runs of the release workflow when some registries already have the version published.

## Test plan

- [ ] Re-tag an existing version to trigger workflow
- [ ] Verify all publish jobs succeed or gracefully skip
- [ ] Verify GitHub Release is created