### PR TITLE
chore: bump aws-lc-rs to 1.16.1 to fix HIGH security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

- Updates `aws-lc-sys` from `0.37.1` to `0.38.0` via `cargo update aws-lc-rs --precise 1.16.1`
- Resolves three open Dependabot HIGH severity alerts:
  - GHSA-vw5v-4f2q-w9xf: PKCS7_verify Certificate Chain Validation Bypass
  - GHSA-65p9-r9h6-22vj: Timing Side-Channel in AES-CCM Tag Verification
  - GHSA-hfpc-8r3f-gw53: PKCS7_verify Signature Validation Bypass

Root cause: `reqwest` feature `rustls` pulls in `hyper-rustls` → `rustls` → `aws-lc-rs` → `aws-lc-sys`.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 476 tests passed
- [x] `cargo deny check` — no errors