### PR TITLE
fix(core): add Atom 0.3 integration tests and fix version/field detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Atom 0.3 feeds now correctly report `version = "atom03"` instead of `"atom10"` (#91)
+- Atom 0.3 `<modified>` and `<issued>` elements are now mapped to `updated` and `published` fields respectively (#91)
+
+### Tests
+- Add integration test fixture and tests for Atom 0.3 feed parsing (#91)
+
 ## [0.4.7] - 2026-03-21
 
 ### Dependencies

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -73,6 +73,14 @@ pub fn parse_atom10_with_limits(data: &[u8], limits: ParserLimits) -> Result<Par
                     base_ctx.update_base(&xml_base);
                 }
 
+                for attr in e.attributes().flatten() {
+                    if attr.key.as_ref() == b"xmlns"
+                        && attr.value.as_ref() == b"http://purl.org/atom/ns#"
+                    {
+                        feed.version = FeedVersion::Atom03;
+                    }
+                }
+
                 depth += 1;
                 if let Err(e) =
                     parse_feed_element(&mut reader, &mut feed, &limits, &mut depth, &base_ctx)
@@ -161,11 +169,11 @@ fn parse_feed_element(
                         }
                         feed.feed.id = Some(text);
                     }
-                    b"updated" if !is_empty => {
+                    b"updated" | b"modified" if !is_empty => {
                         let text = read_text_str(reader, &mut buf, limits)?;
                         feed.feed.updated = parse_date(&text);
                     }
-                    b"published" if !is_empty => {
+                    b"published" | b"issued" if !is_empty => {
                         let text = read_text_str(reader, &mut buf, limits)?;
                         feed.feed.published = parse_date(&text);
                     }
@@ -347,11 +355,11 @@ fn parse_entry(
                         *bozo |= had_bozo;
                         entry.id = Some(text.into());
                     }
-                    b"updated" if !is_empty => {
+                    b"updated" | b"modified" if !is_empty => {
                         let text = read_text_str(reader, buf, limits)?;
                         entry.updated = parse_date(&text);
                     }
-                    b"published" if !is_empty => {
+                    b"published" | b"issued" if !is_empty => {
                         let text = read_text_str(reader, buf, limits)?;
                         entry.published = parse_date(&text);
                     }

--- a/crates/feedparser-rs-core/tests/integration_tests.rs
+++ b/crates/feedparser-rs-core/tests/integration_tests.rs
@@ -279,6 +279,33 @@ fn test_rss10_entry_entity_bozo() {
 }
 
 #[test]
+fn test_parse_atom03_fixture() {
+    let xml = load_fixture("atom/atom03.xml");
+    let result = parse(&xml);
+
+    assert!(result.is_ok(), "Failed to parse Atom 0.3 fixture");
+    let feed = result.unwrap();
+
+    assert!(!feed.bozo, "Well-formed Atom 0.3 feed must not set bozo");
+    assert_eq!(feed.version, FeedVersion::Atom03, "Version must be atom03");
+    assert_eq!(feed.feed.title.as_deref(), Some("Example Atom 0.3 Feed"));
+    assert!(feed.feed.link.is_some(), "Feed link must be populated");
+    assert_eq!(feed.entries.len(), 2, "Feed must have two entries");
+
+    let entry = &feed.entries[0];
+    assert_eq!(entry.title.as_deref(), Some("First Entry"));
+    assert!(entry.id.is_some(), "Entry id must be populated");
+    assert!(entry.updated.is_some(), "Entry updated must be parsed");
+}
+
+#[test]
+fn test_detect_format_atom03_fixture() {
+    let xml = load_fixture("atom/atom03.xml");
+    let version = detect_format(&xml);
+    assert_eq!(version, FeedVersion::Atom03);
+}
+
+#[test]
 fn test_feed_with_standard_entities_no_bozo() {
     let xml = br#"<?xml version="1.0"?>
 <rss version="2.0">

--- a/tests/fixtures/atom/atom03.xml
+++ b/tests/fixtures/atom/atom03.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed version="0.3" xmlns="http://purl.org/atom/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title>Example Atom 0.3 Feed</title>
+  <link rel="alternate" type="text/html" href="http://example.com/"/>
+  <modified>2024-12-14T10:00:00Z</modified>
+  <id>http://example.com/feed</id>
+  <author>
+    <name>John Doe</name>
+    <email>john@example.com</email>
+  </author>
+  <tagline>An example Atom 0.3 feed</tagline>
+
+  <entry>
+    <title>First Entry</title>
+    <link rel="alternate" type="text/html" href="http://example.com/entry1"/>
+    <id>http://example.com/entry1</id>
+    <modified>2024-12-14T09:00:00Z</modified>
+    <issued>2024-12-13T09:00:00Z</issued>
+    <summary>Summary of first entry</summary>
+    <content type="text/html" mode="escaped">&lt;p&gt;Content of first entry&lt;/p&gt;</content>
+    <dc:creator>John Doe</dc:creator>
+  </entry>
+
+  <entry>
+    <title>Second Entry</title>
+    <link rel="alternate" type="text/html" href="http://example.com/entry2"/>
+    <id>http://example.com/entry2</id>
+    <modified>2024-12-13T08:00:00Z</modified>
+    <summary>Summary of second entry</summary>
+  </entry>
+</feed>


### PR DESCRIPTION
## Summary

- Add `atom03.xml` fixture with valid Atom 0.3 namespace (`http://purl.org/atom/ns#`)
- Fix atom parser to detect the Atom 0.3 namespace on `<feed>` and set `version = Atom03` (was always `Atom10`)
- Map Atom 0.3 `<modified>` → `updated` and `<issued>` → `published` fields
- Add `test_parse_atom03_fixture` and `test_detect_format_atom03_fixture` integration tests

## Test plan

- [x] `test_parse_atom03_fixture` — parses fixture, asserts `version == atom03`, title, link, entry count, entry id, entry updated
- [x] `test_detect_format_atom03_fixture` — asserts `detect_format` returns `Atom03`
- [x] `bozo == false` on well-formed Atom 0.3 input
- [x] All 639 existing tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo deny check` clean

Closes #91