### PR TITLE
feat(core): parse Atom entry subtitle element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Parse `<subtitle>` element at the Atom entry level: `Entry` now exposes `subtitle: Option<String>` and `subtitle_detail: Option<TextConstruct>`, mirroring the existing feed-level subtitle fields (#110)
+- Expose `subtitle` and `subtitle_detail` on `Entry` in Python (PyO3) and Node.js (napi-rs) bindings (#110)
+
 ### Fixed
 - Add `tests/fixtures/**` to the `rust-core` paths-filter group so fixture-only PRs correctly trigger Rust test jobs (#107)
 - Fix encoding detection for non-UTF-8 feeds: `extract_xml_encoding` now performs a byte-level search for the XML declaration instead of calling `str::from_utf8` on the full search buffer, which failed when non-ASCII bytes appeared within the first 512 bytes (#95)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -363,6 +363,10 @@ fn parse_entry(
                         let text = read_text_str(reader, buf, limits)?;
                         entry.published = parse_date(&text);
                     }
+                    b"subtitle" if !is_empty => {
+                        let text = parse_text_construct(reader, buf, &element, limits)?;
+                        entry.set_subtitle(text);
+                    }
                     b"summary" if !is_empty => {
                         let text = parse_text_construct(reader, buf, &element, limits)?;
                         entry.set_summary(text);

--- a/crates/feedparser-rs-core/src/types/entry.rs
+++ b/crates/feedparser-rs-core/src/types/entry.rs
@@ -20,6 +20,10 @@ pub struct Entry {
     pub link: Option<String>,
     /// All links associated with this entry
     pub links: Vec<Link>,
+    /// Entry subtitle (Atom §4.2.12 at entry level)
+    pub subtitle: Option<String>,
+    /// Detailed subtitle with metadata
+    pub subtitle_detail: Option<TextConstruct>,
     /// Short description/summary
     pub summary: Option<String>,
     /// Detailed summary with metadata
@@ -132,6 +136,23 @@ impl Entry {
     pub fn set_title(&mut self, mut text: TextConstruct) {
         self.title = Some(std::mem::take(&mut text.value));
         self.title_detail = Some(text);
+    }
+
+    /// Sets subtitle field with `TextConstruct`, storing both simple and detailed versions
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use feedparser_rs::{Entry, TextConstruct};
+    ///
+    /// let mut entry = Entry::default();
+    /// entry.set_subtitle(TextConstruct::text("A teaser"));
+    /// assert_eq!(entry.subtitle.as_deref(), Some("A teaser"));
+    /// ```
+    #[inline]
+    pub fn set_subtitle(&mut self, mut text: TextConstruct) {
+        self.subtitle = Some(std::mem::take(&mut text.value));
+        self.subtitle_detail = Some(text);
     }
 
     /// Sets summary field with `TextConstruct`, storing both simple and detailed versions

--- a/crates/feedparser-rs-core/tests/integration_tests.rs
+++ b/crates/feedparser-rs-core/tests/integration_tests.rs
@@ -7,7 +7,7 @@
     clippy::panic
 )]
 
-use feedparser_rs::{FeedVersion, detect_format, parse};
+use feedparser_rs::{FeedVersion, TextType, detect_format, parse};
 
 /// Helper function to load test fixtures
 fn load_fixture(path: &str) -> Vec<u8> {
@@ -326,4 +326,46 @@ fn test_feed_with_standard_entities_no_bozo() {
         !result.bozo,
         "Feed with only standard entities should not set bozo"
     );
+}
+
+#[test]
+fn test_atom_entry_subtitle_html() {
+    let xml = load_fixture("atom/entry-subtitle.xml");
+    let feed = parse(&xml).unwrap();
+
+    assert!(!feed.bozo, "Valid feed must not set bozo");
+    assert_eq!(feed.entries.len(), 3);
+
+    // First entry: html subtitle with entities
+    let entry = &feed.entries[0];
+    assert_eq!(
+        entry.subtitle.as_deref(),
+        Some("A longer<em>teaser</em>description")
+    );
+    let detail = entry.subtitle_detail.as_ref().unwrap();
+    assert_eq!(detail.content_type, TextType::Html);
+    // summary is independent from subtitle
+    assert_eq!(entry.summary.as_deref(), Some("Plain text summary"));
+
+    // Second entry: subtitle without type attr defaults to "text"
+    let entry2 = &feed.entries[1];
+    assert_eq!(
+        entry2.subtitle.as_deref(),
+        Some("Plain text subtitle without type attribute")
+    );
+    let detail2 = entry2.subtitle_detail.as_ref().unwrap();
+    assert_eq!(detail2.content_type, TextType::Text);
+
+    // Third entry: no subtitle
+    let entry3 = &feed.entries[2];
+    assert!(entry3.subtitle.is_none());
+    assert!(entry3.subtitle_detail.is_none());
+}
+
+#[test]
+fn test_atom_entry_subtitle_does_not_affect_feed_subtitle() {
+    let xml = load_fixture("atom/entry-subtitle.xml");
+    let feed = parse(&xml).unwrap();
+
+    assert_eq!(feed.feed.subtitle.as_deref(), Some("Feed-level subtitle"));
 }

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -431,6 +431,10 @@ pub struct Entry {
     pub link: Option<String>,
     /// All links associated with this entry
     pub links: Vec<Link>,
+    /// Entry subtitle (Atom §4.2.12 at entry level)
+    pub subtitle: Option<String>,
+    /// Detailed subtitle with metadata
+    pub subtitle_detail: Option<TextConstruct>,
     /// Short description/summary
     pub summary: Option<String>,
     /// Detailed summary with metadata
@@ -505,6 +509,8 @@ impl From<CoreEntry> for Entry {
             title_detail: core.title_detail.map(TextConstruct::from),
             link: core.link,
             links: core.links.into_iter().map(Link::from).collect(),
+            subtitle: core.subtitle,
+            subtitle_detail: core.subtitle_detail.map(TextConstruct::from),
             summary: core.summary,
             summary_detail: core.summary_detail.map(TextConstruct::from),
             content: core.content.into_iter().map(Content::from).collect(),

--- a/crates/feedparser-rs-py/src/types/entry.rs
+++ b/crates/feedparser-rs-py/src/types/entry.rs
@@ -56,6 +56,19 @@ impl PyEntry {
     }
 
     #[getter]
+    fn subtitle(&self) -> Option<&str> {
+        self.inner.subtitle.as_deref()
+    }
+
+    #[getter]
+    fn subtitle_detail(&self) -> Option<PyTextConstruct> {
+        self.inner
+            .subtitle_detail
+            .as_ref()
+            .map(|tc| PyTextConstruct::from_core(tc.clone()))
+    }
+
+    #[getter]
     fn summary(&self) -> Option<&str> {
         self.inner.summary.as_deref()
     }
@@ -397,6 +410,20 @@ impl PyEntry {
                 .unbind()),
             "title_detail" => {
                 if let Some(ref tc) = self.inner.title_detail {
+                    Ok(Py::new(py, PyTextConstruct::from_core(tc.clone()))?.into_any())
+                } else {
+                    Ok(py.None())
+                }
+            }
+            "subtitle" => Ok(self
+                .inner
+                .subtitle
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "subtitle_detail" => {
+                if let Some(ref tc) = self.inner.subtitle_detail {
                     Ok(Py::new(py, PyTextConstruct::from_core(tc.clone()))?.into_any())
                 } else {
                     Ok(py.None())

--- a/tests/fixtures/atom/entry-subtitle.xml
+++ b/tests/fixtures/atom/entry-subtitle.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Entry Subtitle Test Feed</title>
+  <link href="http://example.com"/>
+  <updated>2024-12-14T10:00:00Z</updated>
+  <id>http://example.com/feed</id>
+  <subtitle>Feed-level subtitle</subtitle>
+
+  <entry>
+    <title>My Post</title>
+    <link href="http://example.com/entry1"/>
+    <id>http://example.com/entry1</id>
+    <updated>2024-12-14T09:00:00Z</updated>
+    <subtitle type="html">A longer &lt;em&gt;teaser&lt;/em&gt; description</subtitle>
+    <summary>Plain text summary</summary>
+  </entry>
+
+  <entry>
+    <title>Text Subtitle Entry</title>
+    <link href="http://example.com/entry2"/>
+    <id>http://example.com/entry2</id>
+    <updated>2024-12-14T08:00:00Z</updated>
+    <subtitle>Plain text subtitle without type attribute</subtitle>
+  </entry>
+
+  <entry>
+    <title>No Subtitle Entry</title>
+    <link href="http://example.com/entry3"/>
+    <id>http://example.com/entry3</id>
+    <updated>2024-12-14T07:00:00Z</updated>
+    <summary>Only a summary, no subtitle</summary>
+  </entry>
+</feed>


### PR DESCRIPTION
## Summary

- Add `subtitle: Option<String>` and `subtitle_detail: Option<TextConstruct>` to the `Entry` struct, mirroring the existing feed-level subtitle fields
- Handle `<subtitle>` in `parse_entry()` in `parser/atom.rs` via `parse_text_construct`, identical to feed-level subtitle parsing
- Expose both fields in Python (PyO3) bindings with `#[getter]` and `__getitem__` support
- Expose both fields in Node.js (napi-rs) bindings with conversion in `From<CoreEntry>`
- Add `tests/fixtures/atom/entry-subtitle.xml` covering html type, default text type, and absent subtitle
- Add integration tests verifying correct field values, content_type, and isolation from feed-level subtitle

## Bozo pattern gate

- Valid feeds with `<subtitle>` at entry level: `bozo = false`, confirmed by `test_atom_entry_subtitle_html`
- Valid feeds without entry subtitle: `bozo = false`, both subtitle fields `None`
- Feed-level subtitle is unaffected by entry-level parsing: confirmed by `test_atom_entry_subtitle_does_not_affect_feed_subtitle`

Closes #110