### PR TITLE
feat(core): parse thr:count and thr:updated on link[@rel="replies"] (RFC 4685 §4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `next_url` in Node.js bindings as `FeedMeta.next_url`
 - Parse `<subtitle>` element at the Atom entry level: `Entry` now exposes `subtitle: Option<String>` and `subtitle_detail: Option<TextConstruct>`, mirroring the existing feed-level subtitle fields (#110)
 - Expose `subtitle` and `subtitle_detail` on `Entry` in Python (PyO3) and Node.js (napi-rs) bindings (#110)
+- RFC 4685 Atom Threading Extensions: parse `thr:count` (reply count) and `thr:updated` (last reply datetime) attributes on `<link>` elements; exposed as `link.thr_count: Option<u32>` and `link.thr_updated: Option<DateTime<Utc>>` in core, `link.thr_count` / `link.thr_updated` / `link.thr_updated_parsed` in Python bindings, and `link.thrCount` / `link.thrUpdated` in Node.js bindings (#118)
 
 ### Fixed
 - Parse RSS `<category domain="...">` attribute as `Tag.scheme` (#116)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -1029,4 +1029,217 @@ mod tests {
             Some("https://example.com/entry/1")
         );
     }
+
+    #[test]
+    fn test_thr_count_and_updated_happy_path() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies"
+                  thr:count="10" thr:updated="2024-01-15T12:00:00Z"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, Some(10));
+        assert!(replies_link.thr_updated.is_some());
+    }
+
+    #[test]
+    fn test_thr_count_zero() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies" thr:count="0"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, Some(0));
+    }
+
+    #[test]
+    fn test_thr_count_whitespace_trimmed() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies"
+                  thr:count=" 10 " thr:updated=" 2024-01-15T12:00:00Z "/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, Some(10));
+        assert!(replies_link.thr_updated.is_some());
+    }
+
+    #[test]
+    fn test_thr_attrs_missing_yields_none() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, None);
+        assert!(replies_link.thr_updated.is_none());
+    }
+
+    #[test]
+    fn test_thr_count_malformed_no_bozo() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies"
+                  thr:count="abc" thr:updated="not-a-date"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo, "malformed thr: attrs must not set bozo");
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, None);
+        assert!(replies_link.thr_updated.is_none());
+    }
+
+    #[test]
+    fn test_thr_count_negative_no_bozo() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies" thr:count="-5"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, None);
+    }
+
+    #[test]
+    fn test_thr_count_overflow_no_bozo() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="replies" href="http://example.com/replies"
+                  thr:count="99999999999"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        let replies_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("replies"))
+            .expect("replies link");
+        assert_eq!(replies_link.thr_count, None);
+    }
+
+    #[test]
+    fn test_thr_count_on_non_replies_link() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:thr="http://purl.org/syndication/thread/1.0">
+          <title>Test</title>
+          <id>urn:uuid:test</id>
+          <updated>2024-01-15T12:00:00Z</updated>
+          <entry>
+            <title>Post</title>
+            <id>urn:uuid:entry-1</id>
+            <updated>2024-01-15T12:00:00Z</updated>
+            <link rel="alternate" href="http://example.com/post" thr:count="5"/>
+          </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let alt_link = feed.entries[0]
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("alternate"))
+            .expect("alternate link");
+        assert_eq!(alt_link.thr_count, Some(5));
+    }
 }

--- a/crates/feedparser-rs-core/src/types/common.rs
+++ b/crates/feedparser-rs-core/src/types/common.rs
@@ -1,5 +1,6 @@
 use super::generics::{FromAttributes, ParseFrom};
-use crate::util::text::bytes_to_string;
+use crate::util::{date::parse_date, text::bytes_to_string};
+use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 use serde_json::Value;
 use std::ops::Deref;
@@ -440,6 +441,10 @@ pub struct Link {
     pub length: Option<u64>,
     /// Language of the linked resource (stored inline for lang codes ≤24 bytes)
     pub hreflang: Option<SmallString>,
+    /// RFC 4685 §4: number of replies at the IRI
+    pub thr_count: Option<u32>,
+    /// RFC 4685 §4: when the reply resource was last modified
+    pub thr_updated: Option<DateTime<Utc>>,
 }
 
 impl Link {
@@ -453,6 +458,8 @@ impl Link {
             title: None,
             length: None,
             hreflang: None,
+            thr_count: None,
+            thr_updated: None,
         }
     }
 
@@ -472,6 +479,8 @@ impl Link {
             title: None,
             length: None,
             hreflang: None,
+            thr_count: None,
+            thr_updated: None,
         }
     }
 
@@ -485,6 +494,8 @@ impl Link {
             title: None,
             length: None,
             hreflang: None,
+            thr_count: None,
+            thr_updated: None,
         }
     }
 
@@ -762,6 +773,8 @@ impl FromAttributes for Link {
         let mut title = None;
         let mut hreflang = None;
         let mut length = None;
+        let mut thr_count = None;
+        let mut thr_updated = None;
 
         for attr in attrs {
             if attr.value.len() > max_attr_length {
@@ -774,6 +787,12 @@ impl FromAttributes for Link {
                 b"title" => title = Some(bytes_to_string(&attr.value)),
                 b"hreflang" => hreflang = Some(bytes_to_string(&attr.value)),
                 b"length" => length = bytes_to_string(&attr.value).parse().ok(),
+                b"thr:count" => {
+                    thr_count = bytes_to_string(&attr.value).trim().parse::<u32>().ok();
+                }
+                b"thr:updated" => {
+                    thr_updated = parse_date(bytes_to_string(&attr.value).trim());
+                }
                 _ => {}
             }
         }
@@ -787,6 +806,8 @@ impl FromAttributes for Link {
             title,
             length,
             hreflang: hreflang.map(std::convert::Into::into),
+            thr_count,
+            thr_updated,
         })
     }
 }

--- a/crates/feedparser-rs-core/tests/test_thr_namespace.rs
+++ b/crates/feedparser-rs-core/tests/test_thr_namespace.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Integration tests for RFC 4685 Atom Threading Extensions (thr: namespace)
+
+use feedparser_rs::parse;
+
+#[test]
+fn test_thr_count_and_updated_from_fixture() {
+    let xml = include_bytes!("../../../tests/fixtures/atom/thr_count_updated.xml");
+    let feed = parse(xml).unwrap();
+
+    assert!(!feed.bozo, "valid feed must not set bozo");
+    assert_eq!(feed.entries.len(), 5);
+
+    // Entry 1: both thr:count and thr:updated
+    let replies1 = feed.entries[0]
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("replies"))
+        .expect("entry 1 replies link");
+    assert_eq!(replies1.thr_count, Some(10));
+    assert!(replies1.thr_updated.is_some());
+
+    // Entry 2: only thr:count
+    let replies2 = feed.entries[1]
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("replies"))
+        .expect("entry 2 replies link");
+    assert_eq!(replies2.thr_count, Some(5));
+    assert!(replies2.thr_updated.is_none());
+
+    // Entry 3: only thr:updated
+    let replies3 = feed.entries[2]
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("replies"))
+        .expect("entry 3 replies link");
+    assert_eq!(replies3.thr_count, None);
+    assert!(replies3.thr_updated.is_some());
+
+    // Entry 4: thr:count="0" must be Some(0)
+    let replies4 = feed.entries[3]
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("replies"))
+        .expect("entry 4 replies link");
+    assert_eq!(replies4.thr_count, Some(0));
+
+    // Entry 5: malformed values — both must be None, no bozo
+    let replies5 = feed.entries[4]
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("replies"))
+        .expect("entry 5 replies link");
+    assert_eq!(replies5.thr_count, None);
+    assert!(replies5.thr_updated.is_none());
+    assert!(!feed.bozo);
+}

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -616,6 +616,10 @@ pub struct Link {
     pub length: Option<i64>,
     /// Language of the linked resource
     pub hreflang: Option<String>,
+    /// RFC 4685 §4: number of replies at the IRI
+    pub thr_count: Option<u32>,
+    /// RFC 4685 §4: when the reply resource was last modified (RFC 3339)
+    pub thr_updated: Option<String>,
 }
 
 impl From<CoreLink> for Link {
@@ -627,6 +631,8 @@ impl From<CoreLink> for Link {
             title: core.title,
             length: core.length.map(|l| i64::try_from(l).unwrap_or(i64::MAX)),
             hreflang: core.hreflang.map(|s| s.to_string()),
+            thr_count: core.thr_count,
+            thr_updated: core.thr_updated.map(|dt| dt.to_rfc3339()),
         }
     }
 }

--- a/crates/feedparser-rs-py/src/types/common.rs
+++ b/crates/feedparser-rs-py/src/types/common.rs
@@ -1,3 +1,4 @@
+use super::datetime::optional_datetime_to_struct_time;
 use feedparser_rs::{
     Content as CoreContent, Enclosure as CoreEnclosure, Generator as CoreGenerator,
     Image as CoreImage, Link as CoreLink, Person as CorePerson, Source as CoreSource,
@@ -96,6 +97,21 @@ impl PyLink {
     #[getter]
     fn hreflang(&self) -> Option<&str> {
         self.inner.hreflang.as_deref()
+    }
+
+    #[getter]
+    fn thr_count(&self) -> Option<u32> {
+        self.inner.thr_count
+    }
+
+    #[getter]
+    fn thr_updated(&self) -> Option<String> {
+        self.inner.thr_updated.map(|dt| dt.to_rfc3339())
+    }
+
+    #[getter]
+    fn thr_updated_parsed(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        optional_datetime_to_struct_time(py, &self.inner.thr_updated)
     }
 
     fn __repr__(&self) -> String {

--- a/tests/fixtures/atom/thr_count_updated.xml
+++ b/tests/fixtures/atom/thr_count_updated.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:thr="http://purl.org/syndication/thread/1.0">
+  <title>Threading Test</title>
+  <link href="http://example.com/"/>
+  <id>urn:uuid:test-thr</id>
+  <updated>2024-01-15T12:00:00Z</updated>
+  <entry>
+    <title>Post with both thr attrs</title>
+    <id>urn:uuid:entry-1</id>
+    <updated>2024-01-15T12:00:00Z</updated>
+    <link rel="replies"
+          type="application/atom+xml"
+          href="http://example.com/post/1/replies"
+          thr:count="10"
+          thr:updated="2024-01-15T12:00:00Z"/>
+    <link rel="alternate" href="http://example.com/post/1"/>
+  </entry>
+  <entry>
+    <title>Post with only thr:count</title>
+    <id>urn:uuid:entry-2</id>
+    <updated>2024-01-15T12:00:00Z</updated>
+    <link rel="replies"
+          href="http://example.com/post/2/replies"
+          thr:count="5"/>
+    <link rel="alternate" href="http://example.com/post/2"/>
+  </entry>
+  <entry>
+    <title>Post with only thr:updated</title>
+    <id>urn:uuid:entry-3</id>
+    <updated>2024-01-15T12:00:00Z</updated>
+    <link rel="replies"
+          href="http://example.com/post/3/replies"
+          thr:updated="2024-01-10T08:00:00Z"/>
+    <link rel="alternate" href="http://example.com/post/3"/>
+  </entry>
+  <entry>
+    <title>Post with zero replies</title>
+    <id>urn:uuid:entry-4</id>
+    <updated>2024-01-15T12:00:00Z</updated>
+    <link rel="replies"
+          href="http://example.com/post/4/replies"
+          thr:count="0"/>
+    <link rel="alternate" href="http://example.com/post/4"/>
+  </entry>
+  <entry>
+    <title>Post with malformed thr attrs</title>
+    <id>urn:uuid:entry-5</id>
+    <updated>2024-01-15T12:00:00Z</updated>
+    <link rel="replies"
+          href="http://example.com/post/5/replies"
+          thr:count="abc"
+          thr:updated="not-a-date"/>
+    <link rel="alternate" href="http://example.com/post/5"/>
+  </entry>
+</feed>


### PR DESCRIPTION
## Summary

- Extend `Link` struct with `thr_count: Option<u32>` and `thr_updated: Option<DateTime<Utc>>` (RFC 4685 §4)
- Parse `thr:count` and `thr:updated` attributes in `Link::from_attributes()` with whitespace trimming; malformed or overflow values resolve to `None` without setting `bozo`
- Python bindings: `thr_count`, `thr_updated`, `thr_updated_parsed` (returns `time.struct_time`) on `Link`
- Node.js bindings: `thrCount`, `thrUpdated` (RFC 3339 string) on `Link`
- Test fixture: `tests/fixtures/atom/thr_count_updated.xml` with 5 entries covering all edge cases
- 8 unit tests + 1 integration test

## Bozo pattern gate

- Valid feeds with `thr:count` and `thr:updated` — bozo NOT set
- Malformed count (non-numeric, negative, overflow) — resolves to `None`, bozo NOT set
- Malformed date — resolves to `None`, bozo NOT set

## Test plan

- [x] 723/723 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo deny check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean

## Notes

`thr:count` and `thr:updated` are parsed on all `<link>` elements regardless of `rel` value. RFC 4685 defines these semantically only on `rel="replies"`, but storing them generically is consistent with how other `thr:` attributes work in this codebase. A non-replies link with these attributes will have them accessible but semantically meaningless.

Closes #118