### PR TITLE
release: v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-03-23
+
 ### Added
 - feat(core): populate `feed.next_url` from Atom/RSS `<link rel="next">` per RFC 5005 (#120)
 - Atom Threading Extensions (RFC 4685) support: parse `thr:in-reply-to` and `thr:total` elements in Atom 1.0, RSS 2.0, and RSS 1.0 feeds (#111)
@@ -285,7 +287,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage
 - Documentation with examples
 
-[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.7...HEAD
+[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.8...HEAD
+[0.4.8]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.4...v0.4.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "feedparser-rs"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "ammonia",
  "chrono",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-node"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "feedparser-rs",
  "napi",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-py"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "chrono",
  "feedparser-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["bug-ops"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ High-performance RSS/Atom/JSON Feed parser written in Rust, with Python and Node
 | Syndication | Update schedule (period, frequency, base) |
 | GeoRSS | Geographic location data (point, line, polygon, box) |
 | Creative Commons | License information with `rel="license"` links |
+| Slash | Comment count (`slash:comments`) |
+| WFW | Comment feed URL (`wfw:commentRss`) |
+| Atom Threading (thr:) | In-reply-to, reply count, reply datetime (RFC 4685) |
 
 ## Installation
 
@@ -54,7 +57,7 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs = "0.4"
+feedparser-rs = "0.4.8"
 ```
 
 > [!IMPORTANT]
@@ -184,7 +187,7 @@ To disable HTTP support and reduce dependencies:
 
 ```toml
 [dependencies]
-feedparser-rs = { version = "0.4", default-features = false }
+feedparser-rs = { version = "0.4.8", default-features = false }
 ```
 
 ## Workspace Structure

--- a/crates/feedparser-rs-node/package.json
+++ b/crates/feedparser-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedparser-rs",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "High-performance RSS/Atom/JSON Feed parser for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/feedparser-rs-py/pyproject.toml
+++ b/crates/feedparser-rs-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feedparser-rs"
-version = "0.4.7"
+version = "0.4.8"
 description = "High-performance RSS/Atom/JSON Feed parser with feedparser-compatible API"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump version from 0.4.7 to 0.4.8
- Update CHANGELOG.md with release section dated 2026-03-23
- Update README with namespace extensions (slash:, wfw:, thr:) and version references
- Update package.json and pyproject.toml to 0.4.8

## Checklist

- [x] Version updated in all manifests (Cargo.toml, package.json, pyproject.toml)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version and features
- [x] All CI checks pass (765 tests, clippy clean, fmt clean)
- [ ] Ready for tagging after merge