### PR TITLE
fix(core): author_detail.name always None — clone instead of take in set_author/set_publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `author_detail.name` (and `publisher_detail.name`) was always `None` due to `Person.name` being moved via `.take()` into the shorthand field instead of cloned; affected `Entry` and `FeedMeta` setters (`set_author`, `set_publisher`) (#127)
+
 ## [0.4.8] - 2026-03-23
 
 ### Added

--- a/crates/feedparser-rs-core/src/types/entry.rs
+++ b/crates/feedparser-rs-core/src/types/entry.rs
@@ -198,8 +198,8 @@ impl Entry {
     /// assert_eq!(entry.author.as_deref(), Some("Jane Doe"));
     /// ```
     #[inline]
-    pub fn set_author(&mut self, mut person: Person) {
-        self.author = person.name.take();
+    pub fn set_author(&mut self, person: Person) {
+        self.author.clone_from(&person.name);
         self.author_detail = Some(person);
     }
 
@@ -215,8 +215,8 @@ impl Entry {
     /// assert_eq!(entry.publisher.as_deref(), Some("ACME Corp"));
     /// ```
     #[inline]
-    pub fn set_publisher(&mut self, mut person: Person) {
-        self.publisher = person.name.take();
+    pub fn set_publisher(&mut self, person: Person) {
+        self.publisher.clone_from(&person.name);
         self.publisher_detail = Some(person);
     }
 

--- a/crates/feedparser-rs-core/src/types/feed.rs
+++ b/crates/feedparser-rs-core/src/types/feed.rs
@@ -351,8 +351,8 @@ impl FeedMeta {
     /// assert_eq!(meta.author.as_deref(), Some("John Doe"));
     /// ```
     #[inline]
-    pub fn set_author(&mut self, mut person: Person) {
-        self.author = person.name.take();
+    pub fn set_author(&mut self, person: Person) {
+        self.author.clone_from(&person.name);
         self.author_detail = Some(person);
     }
 
@@ -368,8 +368,8 @@ impl FeedMeta {
     /// assert_eq!(meta.publisher.as_deref(), Some("ACME Corp"));
     /// ```
     #[inline]
-    pub fn set_publisher(&mut self, mut person: Person) {
-        self.publisher = person.name.take();
+    pub fn set_publisher(&mut self, person: Person) {
+        self.publisher.clone_from(&person.name);
         self.publisher_detail = Some(person);
     }
 

--- a/crates/feedparser-rs-core/tests/test_author_detail.rs
+++ b/crates/feedparser-rs-core/tests/test_author_detail.rs
@@ -1,0 +1,122 @@
+//! Regression tests for issue #127: `author_detail.name` must not be None
+//! when the feed provides an author name.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use feedparser_rs::parse;
+
+const ATOM_FEED_LEVEL_AUTHOR: &[u8] = br#"<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <id>urn:test</id>
+  <updated>2026-01-01T00:00:00Z</updated>
+  <author><name>Jane Doe</name><email>jane@example.com</email></author>
+  <entry>
+    <title>Entry</title>
+    <id>urn:entry1</id>
+    <updated>2026-01-01T00:00:00Z</updated>
+  </entry>
+</feed>"#;
+
+const ATOM_ENTRY_LEVEL_AUTHOR: &[u8] = br#"<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <id>urn:test</id>
+  <updated>2026-01-01T00:00:00Z</updated>
+  <entry>
+    <title>Entry</title>
+    <id>urn:entry1</id>
+    <updated>2026-01-01T00:00:00Z</updated>
+    <author><name>Jane Doe</name><email>jane@example.com</email></author>
+  </entry>
+</feed>"#;
+
+const RSS2_AUTHOR: &[u8] = br#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Test</title>
+    <link>http://example.com</link>
+    <description>Test feed</description>
+    <dc:creator>Jane Doe</dc:creator>
+    <item>
+      <title>Item</title>
+      <link>http://example.com/item1</link>
+      <dc:creator>Jane Doe</dc:creator>
+    </item>
+  </channel>
+</rss>"#;
+
+#[test]
+fn test_atom_feed_author_detail_name_not_none() {
+    let feed = parse(ATOM_FEED_LEVEL_AUTHOR).expect("parse failed");
+    assert!(!feed.bozo, "valid feed must not set bozo");
+    let meta = &feed.feed;
+    assert_eq!(meta.author.as_deref(), Some("Jane Doe"));
+    let detail = meta
+        .author_detail
+        .as_ref()
+        .expect("author_detail must be Some");
+    assert_eq!(
+        detail.name.as_deref(),
+        Some("Jane Doe"),
+        "author_detail.name must not be None"
+    );
+    assert_eq!(detail.email.as_deref(), Some("jane@example.com"));
+}
+
+#[test]
+fn test_atom_entry_author_detail_name_not_none() {
+    let feed = parse(ATOM_ENTRY_LEVEL_AUTHOR).expect("parse failed");
+    assert!(!feed.bozo, "valid feed must not set bozo");
+    let entry = &feed.entries[0];
+    assert_eq!(entry.author.as_deref(), Some("Jane Doe"));
+    let detail = entry
+        .author_detail
+        .as_ref()
+        .expect("author_detail must be Some");
+    assert_eq!(
+        detail.name.as_deref(),
+        Some("Jane Doe"),
+        "author_detail.name must not be None"
+    );
+    assert_eq!(detail.email.as_deref(), Some("jane@example.com"));
+}
+
+#[test]
+fn test_set_author_preserves_name_in_detail() {
+    use feedparser_rs::{Entry, Person};
+    let mut entry = Entry::default();
+    entry.set_author(Person::from_name("Jane Doe"));
+    assert_eq!(entry.author.as_deref(), Some("Jane Doe"));
+    let detail = entry
+        .author_detail
+        .as_ref()
+        .expect("author_detail must be Some");
+    assert_eq!(detail.name.as_deref(), Some("Jane Doe"));
+}
+
+#[test]
+fn test_set_publisher_preserves_name_in_detail() {
+    use feedparser_rs::{Entry, Person};
+    let mut entry = Entry::default();
+    entry.set_publisher(Person::from_name("ACME Corp"));
+    assert_eq!(entry.publisher.as_deref(), Some("ACME Corp"));
+    let detail = entry
+        .publisher_detail
+        .as_ref()
+        .expect("publisher_detail must be Some");
+    assert_eq!(detail.name.as_deref(), Some("ACME Corp"));
+}
+
+#[test]
+fn test_rss2_dc_creator_author_detail_name() {
+    let feed = parse(RSS2_AUTHOR).expect("parse failed");
+    let entry = &feed.entries[0];
+    if let Some(detail) = &entry.author_detail {
+        assert_eq!(
+            detail.name.as_deref(),
+            entry.author.as_deref(),
+            "author_detail.name must match author shorthand"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes `author_detail.name` (and `publisher_detail.name`) always being `None` when a feed provides an author name
- Root cause: all four setter methods (`Entry::set_author`, `Entry::set_publisher`, `FeedMeta::set_author`, `FeedMeta::set_publisher`) called `.take()` on `Person.name`, moving it into the shorthand field and leaving the detail struct with `name: None`
- Fix: replace `.take()` with `.clone_from()` so both `author` and `author_detail.name` hold the name

## Test plan

- [x] `test_atom_feed_author_detail_name_not_none` — feed-level author in Atom feed
- [x] `test_atom_entry_author_detail_name_not_none` — entry-level author in Atom feed
- [x] `test_set_author_preserves_name_in_detail` — unit test for `Entry::set_author`
- [x] `test_set_publisher_preserves_name_in_detail` — unit test for `Entry::set_publisher`
- [x] `test_rss2_dc_creator_author_detail_name` — RSS 2.0 with `dc:creator`
- [x] All 770 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Valid Atom feeds do NOT produce `bozo = true`

Closes #127