### PR TITLE
fix(core): map RSS <copyright> to feed.rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Map RSS 2.0 `<copyright>` channel element to `feed.rights` (#144)
 - Parse Atom `<rights>` at entry level into `entry.rights` and `entry.rights_detail`; map `dc:rights` on entries to `entry.rights` (when not already set by Atom) and `entry.dc_rights`; expose `rights`, `rights_detail`, `copyright`, `copyright_detail` in Python bindings and `rights`, `rightsDetail` in Node.js bindings (#139)
 - `TextConstruct.value` (`title_detail.value`, `summary_detail.value`, `subtitle_detail.value`, `rights_detail.value`) was always empty due to `mem::take` moving the string into the shorthand field; fixed by cloning instead (#136)
 - `TextConstruct.type` now returns MIME types matching Python feedparser: `text/plain`, `text/html`, `application/xhtml+xml` instead of short forms `text`, `html`, `xhtml` (#136)

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -185,7 +185,7 @@ fn parse_channel(
                 // Use full qualified name to distinguish standard RSS tags from namespaced tags
                 match tag.as_slice() {
                     b"title" | b"link" | b"description" | b"language" | b"pubDate"
-                    | b"managingEditor" | b"webMaster" | b"generator" | b"ttl"
+                    | b"managingEditor" | b"webMaster" | b"generator" | b"ttl" | b"copyright"
                         if !is_empty =>
                     {
                         parse_channel_standard(
@@ -447,6 +447,12 @@ fn parse_channel_standard(
         b"webMaster" => {
             let text = read_text_str(reader, buf, limits)?;
             feed.feed.set_publisher(parse_rss_person(&text));
+        }
+        b"copyright" => {
+            let text = read_text_str(reader, buf, limits)?;
+            if !text.is_empty() {
+                feed.feed.rights = Some(text);
+            }
         }
         b"generator" => {
             feed.feed.generator = Some(read_text_str(reader, buf, limits)?);
@@ -1902,6 +1908,22 @@ mod tests {
 
         let feed = parse_rss20(xml).unwrap();
         assert_eq!(feed.feed.language.as_deref(), Some("en-US"));
+    }
+
+    #[test]
+    fn test_parse_rss_copyright_maps_to_rights() {
+        let xml = br#"<?xml version="1.0"?><rss version="2.0"><channel>
+            <title>T</title><link>http://x.com</link>
+            <copyright>Copyright 2026 ACME Corp</copyright>
+            <item><title>I</title></item>
+        </channel></rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.rights.as_deref(),
+            Some("Copyright 2026 ACME Corp")
+        );
+        assert!(!feed.bozo);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- RSS 2.0 `<copyright>` channel element was silently dropped during parsing
- Added handling to map it to `feed.rights`, matching Python feedparser behavior
- Added regression test with the reproduction case from the issue

## Test plan

- [x] `cargo nextest run` — 784 tests passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Valid feed with `<copyright>` returns correct `feed.rights` and `bozo = false`

Closes #144