### PR TITLE
fix(core): dc:creator takes priority over author in entry.author flat field (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Core: when an RSS entry (or feed) has both `<author>` and `<dc:creator>`, `entry.author` now returns the `dc:creator` value (dc:creator always wins); previously dc:creator only set `entry.author` if it was not already set (#172)
+- Core: when an RSS `<author>` element contains the `email@x.com (Name)` format, `entry.author` now returns the raw string (e.g. `"email@x.com (Name)"`); `entry.author_detail` still contains the parsed name and email fields; previously only the parsed name was stored in `entry.author` (#172)
 - Atom feeds with `type="xhtml"` content now preserve inner HTML markup; the outer `<div xmlns="...xhtml">` wrapper is stripped per RFC 4287 §3.1.1.3; applies to `content`, `summary`, `title`, `rights`, and `subtitle` fields; previously all tags were stripped leaving bare concatenated text (#169)
 - Atom `<content type="xhtml">` now normalizes the `content_type` field to `"application/xhtml+xml"`; `"html"` normalizes to `"text/html"` and `"text"` to `"text/plain"`, matching Python feedparser MIME type output (#170)
 - Python and Node.js bindings: `entry.slash_comments` now returns a string (e.g. `'42'`) instead of an integer, matching Python feedparser behavior and the existing `thr_total` string convention (#168)

--- a/crates/feedparser-rs-core/src/namespace/dublin_core.rs
+++ b/crates/feedparser-rs-core/src/namespace/dublin_core.rs
@@ -32,10 +32,8 @@ pub const DC_NAMESPACE: &str = "http://purl.org/dc/elements/1.1/";
 pub fn handle_feed_element(element: &str, text: &str, feed: &mut FeedMeta) {
     match element {
         "creator" => {
-            // dc:creator → author (if not already set)
-            if feed.author.is_none() {
-                feed.author = Some(text.into());
-            }
+            // dc:creator → author (always overrides)
+            feed.author = Some(text.into());
             // Store in dc_creator field
             feed.dc_creator = Some(text.into());
             // Also add to authors list
@@ -112,9 +110,7 @@ pub fn handle_feed_element(element: &str, text: &str, feed: &mut FeedMeta) {
 pub fn handle_entry_element(element: &str, text: &str, entry: &mut Entry) {
     match element {
         "creator" => {
-            if entry.author.is_none() {
-                entry.author = Some(text.into());
-            }
+            // dc:creator takes precedence over <author>; reconciled at </item>
             entry.dc_creator = Some(text.into());
             entry.authors.push(Person::from_name(text));
         }
@@ -182,8 +178,8 @@ mod tests {
         handle_feed_element("creator", "Alice", &mut feed);
         handle_feed_element("creator", "Bob", &mut feed);
 
-        // First creator becomes primary author
-        assert_eq!(feed.author.as_deref(), Some("Alice"));
+        // Last dc:creator wins (always overrides)
+        assert_eq!(feed.author.as_deref(), Some("Bob"));
         // Both are in authors list
         assert_eq!(feed.authors.len(), 2);
     }
@@ -237,7 +233,8 @@ mod tests {
         handle_entry_element("subject", "Tech", &mut entry);
         handle_entry_element("description", "Entry summary", &mut entry);
 
-        assert_eq!(entry.author.as_deref(), Some("Jane Doe"));
+        // dc:creator is stored in dc_creator; entry.author is reconciled at </item> in rss.rs
+        assert_eq!(entry.dc_creator.as_deref(), Some("Jane Doe"));
         assert_eq!(entry.tags.len(), 1);
         assert_eq!(entry.summary.as_deref(), Some("Entry summary"));
     }

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -482,6 +482,8 @@ fn parse_channel_standard(
         b"managingEditor" => {
             let text = read_text_str(reader, buf, limits)?;
             feed.feed.set_author(parse_rss_person(&text));
+            // Preserve raw string in author flat field; author_detail has parsed fields
+            feed.feed.author = Some(text.into());
         }
         b"webMaster" => {
             let text = read_text_str(reader, buf, limits)?;
@@ -942,6 +944,11 @@ fn parse_item(
         buf.clear();
     }
 
+    // dc:creator takes precedence over <author>
+    if let Some(dc) = &entry.dc_creator {
+        entry.author = Some(dc.clone());
+    }
+
     Ok((entry, has_attr_errors, has_entity_bozo))
 }
 
@@ -1007,6 +1014,8 @@ fn parse_item_standard(
             let (text, had_bozo) = read_text(reader, buf, limits)?;
             *bozo |= had_bozo;
             entry.set_author(parse_rss_person(&text));
+            // Preserve raw string in author flat field; author_detail has parsed fields
+            entry.author = Some(text.into());
         }
         b"category" => {
             let scheme = find_attribute(attrs, b"domain").map(|s| s.to_owned().into());
@@ -1921,7 +1930,11 @@ mod tests {
         </rss>"#;
 
         let feed = parse_rss20(xml).unwrap();
-        assert_eq!(feed.entries[0].author.as_deref(), Some("John Doe"));
+        // author flat field preserves raw string
+        assert_eq!(
+            feed.entries[0].author.as_deref(),
+            Some("john@example.com (John Doe)")
+        );
         let detail = feed.entries[0].author_detail.as_ref().unwrap();
         assert_eq!(detail.name.as_deref(), Some("John Doe"));
         assert_eq!(detail.email.as_deref(), Some("john@example.com"));
@@ -2819,12 +2832,20 @@ mod tests {
         let author_detail = feed.feed.author_detail.as_ref().unwrap();
         assert_eq!(author_detail.name.as_deref(), Some("John Editor"));
         assert_eq!(author_detail.email.as_deref(), Some("editor@example.com"));
-        assert_eq!(feed.feed.author.as_deref(), Some("John Editor"));
+        // author flat field preserves raw string
+        assert_eq!(
+            feed.feed.author.as_deref(),
+            Some("editor@example.com (John Editor)")
+        );
 
         let entry_detail = feed.entries[0].author_detail.as_ref().unwrap();
         assert_eq!(entry_detail.name.as_deref(), Some("Jane Author"));
         assert_eq!(entry_detail.email.as_deref(), Some("author@example.com"));
-        assert_eq!(feed.entries[0].author.as_deref(), Some("Jane Author"));
+        // author flat field preserves raw string
+        assert_eq!(
+            feed.entries[0].author.as_deref(),
+            Some("author@example.com (Jane Author)")
+        );
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/parser/rss10.rs
+++ b/crates/feedparser-rs-core/src/parser/rss10.rs
@@ -391,6 +391,11 @@ fn parse_item(
         buf.clear();
     }
 
+    // dc:creator takes precedence over <author>
+    if let Some(dc) = &entry.dc_creator {
+        entry.author = Some(dc.clone());
+    }
+
     Ok(entry)
 }
 

--- a/crates/feedparser-rs-core/tests/namespace_edge_cases.rs
+++ b/crates/feedparser-rs-core/tests/namespace_edge_cases.rs
@@ -136,10 +136,10 @@ fn test_dc_fallback_behavior() {
     assert_eq!(feed.feed.author.as_deref(), Some("DC Author"));
     assert_eq!(feed.feed.dc_creator.as_deref(), Some("DC Author"));
 
-    // Entry level: RSS author should take precedence, but dc_creator is also stored.
-    // The email (Name) format is parsed: author string becomes the name.
+    // Entry level: dc:creator takes precedence over <author> (regardless of order).
     let entry = &feed.entries[0];
-    assert_eq!(entry.author.as_deref(), Some("RSS Author"));
+    assert_eq!(entry.author.as_deref(), Some("DC Entry Author"));
+    // author_detail is parsed from <author> element
     let detail = entry.author_detail.as_ref().unwrap();
     assert_eq!(detail.name.as_deref(), Some("RSS Author"));
     assert_eq!(detail.email.as_deref(), Some("rss@example.com"));

--- a/crates/feedparser-rs-core/tests/test_entry_author_precedence.rs
+++ b/crates/feedparser-rs-core/tests/test_entry_author_precedence.rs
@@ -1,0 +1,65 @@
+//! Tests for issue #172: entry.author precedence and raw string format.
+//!
+//! 1. dc:creator must override <author> in entry.author
+//! 2. <author> raw string must be preserved in entry.author (not parsed name)
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use feedparser_rs::parse;
+
+#[test]
+fn test_dc_creator_overrides_author() {
+    let xml = include_bytes!("../../../tests/fixtures/rss/entry_author_dc_creator.xml");
+    let result = parse(xml).unwrap();
+    let entry = &result.entries[0];
+
+    // dc:creator wins over <author>
+    assert_eq!(entry.author.as_deref(), Some("DC Creator"));
+    // author_detail should be parsed from <author>
+    let detail = entry
+        .author_detail
+        .as_ref()
+        .expect("author_detail must be set");
+    assert_eq!(detail.name.as_deref(), Some("Name"));
+    assert_eq!(detail.email.as_deref(), Some("email@x.com"));
+    // dc_creator field
+    assert_eq!(entry.dc_creator.as_deref(), Some("DC Creator"));
+    // feed must not have bozo
+    assert!(!result.bozo);
+}
+
+#[test]
+fn test_dc_creator_overrides_author_when_dc_first() {
+    // Regression test for order-dependent bug: dc:creator appears BEFORE <author>
+    let xml = include_bytes!("../../../tests/fixtures/rss/entry_author_dc_creator_first.xml");
+    let result = parse(xml).unwrap();
+    let entry = &result.entries[0];
+
+    // dc:creator must win even when it appears before <author>
+    assert_eq!(entry.author.as_deref(), Some("DC Creator"));
+    let detail = entry
+        .author_detail
+        .as_ref()
+        .expect("author_detail must be set");
+    assert_eq!(detail.name.as_deref(), Some("Name"));
+    assert_eq!(detail.email.as_deref(), Some("email@x.com"));
+    assert_eq!(entry.dc_creator.as_deref(), Some("DC Creator"));
+    assert!(!result.bozo);
+}
+
+#[test]
+fn test_author_raw_string_preserved() {
+    let xml = include_bytes!("../../../tests/fixtures/rss/entry_author_raw.xml");
+    let result = parse(xml).unwrap();
+    let entry = &result.entries[0];
+
+    // author flat field must be the raw string, not parsed name
+    assert_eq!(entry.author.as_deref(), Some("email@x.com (Author Name)"));
+    // author_detail must have parsed fields
+    let detail = entry
+        .author_detail
+        .as_ref()
+        .expect("author_detail must be set");
+    assert_eq!(detail.name.as_deref(), Some("Author Name"));
+    assert!(!result.bozo);
+}

--- a/tests/fixtures/rss/entry_author_dc_creator.xml
+++ b/tests/fixtures/rss/entry_author_dc_creator.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <description>Test feed for dc:creator precedence</description>
+    <item>
+      <title>Test Entry</title>
+      <link>https://example.com/entry1</link>
+      <author>email@x.com (Name)</author>
+      <dc:creator>DC Creator</dc:creator>
+      <description>Test entry body</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/rss/entry_author_dc_creator_first.xml
+++ b/tests/fixtures/rss/entry_author_dc_creator_first.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <description>Test feed for dc:creator precedence when dc:creator appears first</description>
+    <item>
+      <title>Test Entry</title>
+      <link>https://example.com/entry1</link>
+      <dc:creator>DC Creator</dc:creator>
+      <author>email@x.com (Name)</author>
+      <description>Test entry body</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/rss/entry_author_raw.xml
+++ b/tests/fixtures/rss/entry_author_raw.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <description>Test feed for raw author string</description>
+    <item>
+      <title>Test Entry</title>
+      <link>https://example.com/entry1</link>
+      <author>email@x.com (Author Name)</author>
+      <description>Test entry body</description>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- `dc:creator` now unconditionally overrides `entry.author` regardless of element order in the feed XML
- `<author>` with `email (Name)` format now preserves the raw string in `entry.author`; `author_detail` remains correctly parsed
- Post-processing step added in `rss.rs` and `rss10.rs` after `</item>` to promote `dc_creator` into `entry.author`

## Root causes fixed

1. **dc:creator precedence was order-dependent**: the previous fix only worked when `<dc:creator>` appeared after `<author>` in the document. Solved by storing dc:creator in `entry.dc_creator` during parsing and applying precedence in a post-processing step.

2. **Raw author string was discarded**: `entry.author` stored the parsed name from `email (Name)` format. Fixed by setting `entry.author = Some(raw_text)` after `set_author()`.

## Bozo pattern gate

- Valid feeds: `bozo = false` — confirmed
- Malformed feeds not affected by these changes

## Test plan

- [ ] `test_dc_creator_overrides_author` — dc:creator after author in XML
- [ ] `test_dc_creator_overrides_author_when_dc_first` — dc:creator before author in XML (regression for order-dependent bug)
- [ ] `test_author_raw_string_preserved` — raw string when no dc:creator
- [ ] 841/841 tests pass

Fixes #172