### PR TITLE
fix(core): map dc:date to entry.updated in RSS 1.0 feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Core: `dc:date` in RSS 1.0 (RDF) feeds now maps to `entry.updated`/`entry.updated_parsed` instead of `entry.published`/`entry.published_parsed`, matching Python feedparser behavior (#175)
 - Core, Python, Node.js bindings: `Link.length`, `Enclosure.length`, `MediaContent.width`, `MediaContent.height`, `MediaThumbnail.width`, and `MediaThumbnail.height` now return `str` (raw XML attribute value) instead of an integer, matching Python feedparser behavior; non-numeric values are preserved as-is rather than silently dropped (#173)
 - Core: when an RSS entry (or feed) has both `<author>` and `<dc:creator>`, `entry.author` now returns the `dc:creator` value (dc:creator always wins); previously dc:creator only set `entry.author` if it was not already set (#172)
 - Core: when an RSS `<author>` element contains the `email@x.com (Name)` format, `entry.author` now returns the raw string (e.g. `"email@x.com (Name)"`); `entry.author_detail` still contains the parsed name and email fields; previously only the parsed name was stored in `entry.author` (#172)

--- a/crates/feedparser-rs-core/src/namespace/dublin_core.rs
+++ b/crates/feedparser-rs-core/src/namespace/dublin_core.rs
@@ -117,10 +117,9 @@ pub fn handle_entry_element(element: &str, text: &str, entry: &mut Entry) {
         "date" => {
             if let Some(dt) = parse_date(text) {
                 entry.dc_date = Some(dt);
-                // Prefer published over updated for entries
-                if entry.published.is_none() {
-                    entry.published = Some(dt);
-                    entry.published_str = Some(text.to_string());
+                if entry.updated.is_none() {
+                    entry.updated = Some(dt);
+                    entry.updated_str = Some(text.to_string());
                 }
             }
         }
@@ -240,11 +239,12 @@ mod tests {
     }
 
     #[test]
-    fn test_entry_published_from_dc_date() {
+    fn test_entry_updated_from_dc_date() {
         let mut entry = Entry::default();
         handle_entry_element("date", "2024-01-15T10:30:00Z", &mut entry);
 
-        assert!(entry.published.is_some());
+        assert!(entry.updated.is_some());
+        assert!(entry.published.is_none());
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/parser/rss10.rs
+++ b/crates/feedparser-rs-core/src/parser/rss10.rs
@@ -533,8 +533,9 @@ mod tests {
 
         assert_eq!(feed.entries.len(), 1);
         let entry = &feed.entries[0];
-        assert!(entry.published.is_some());
-        let dt = entry.published.unwrap();
+        assert!(entry.updated.is_some());
+        assert!(entry.published.is_none());
+        let dt = entry.updated.unwrap();
         assert_eq!(dt.year(), 2024);
         assert_eq!(dt.month(), 12);
         assert_eq!(dt.day(), 15);
@@ -658,6 +659,27 @@ mod tests {
         assert!(is_dc_tag(b"title").is_none());
         assert!(is_dc_tag(b"link").is_none());
         assert!(is_dc_tag(b"atom:title").is_none());
+    }
+
+    #[test]
+    fn test_dc_date_maps_to_updated_not_published() {
+        let xml = include_bytes!("../../../../tests/fixtures/rss10_dc_date.xml");
+        let feed = parse_rss10(xml).unwrap();
+        assert_eq!(feed.entries.len(), 1);
+        let entry = &feed.entries[0];
+        assert!(
+            entry.updated.is_some(),
+            "entry.updated should be set from dc:date"
+        );
+        assert!(
+            entry.published.is_none(),
+            "entry.published should not be set from dc:date"
+        );
+        let dt = entry.updated.unwrap();
+        assert_eq!(dt.year(), 2025);
+        assert_eq!(dt.month(), 1);
+        assert_eq!(dt.day(), 15);
+        assert_eq!(entry.updated_str.as_deref(), Some("2025-01-15T10:00:00Z"));
     }
 
     #[test]

--- a/crates/feedparser-rs-core/tests/test_rss10.rs
+++ b/crates/feedparser-rs-core/tests/test_rss10.rs
@@ -107,16 +107,17 @@ fn test_rss10_with_dublin_core() {
     let entry = &feed.entries[0];
     assert_eq!(entry.author.as_deref(), Some("John Doe"));
     assert!(
-        entry.published.is_some(),
-        "dc:date should be parsed as published date"
+        entry.updated.is_some(),
+        "dc:date should be parsed as updated date"
     );
+    assert!(entry.published.is_none(), "dc:date must not set published");
 
-    if let Some(published) = entry.published {
-        assert_eq!(published.year(), 2024);
-        assert_eq!(published.month(), 12);
-        assert_eq!(published.day(), 18);
-        assert_eq!(published.hour(), 9);
-        assert_eq!(published.minute(), 30);
+    if let Some(updated) = entry.updated {
+        assert_eq!(updated.year(), 2024);
+        assert_eq!(updated.month(), 12);
+        assert_eq!(updated.day(), 18);
+        assert_eq!(updated.hour(), 9);
+        assert_eq!(updated.minute(), 30);
     }
 }
 
@@ -436,7 +437,7 @@ fn test_rss10_real_world_slashdot_like() {
     let first = &feed.entries[0];
     assert_eq!(first.title.as_deref(), Some("New Technology Breakthrough"));
     assert_eq!(first.author.as_deref(), Some("BeauHD"));
-    assert!(first.published.is_some());
+    assert!(first.updated.is_some());
 
     let second = &feed.entries[1];
     assert_eq!(

--- a/tests/fixtures/rss10_dc_date.xml
+++ b/tests/fixtures/rss10_dc_date.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns="http://purl.org/rss/1.0/"
+         xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel rdf:about="http://example.com/">
+    <title>Test</title>
+    <link>http://example.com/</link>
+  </channel>
+  <item rdf:about="http://example.com/item1">
+    <title>Item</title>
+    <link>http://example.com/item1</link>
+    <dc:date>2025-01-15T10:00:00Z</dc:date>
+  </item>
+</rdf:RDF>


### PR DESCRIPTION
Fixes #175

## Summary

- `dc:date` in RSS 1.0 (RDF) feeds now maps to `entry.updated`/`entry.updated_parsed` instead of `entry.published`/`entry.published_parsed`, matching Python feedparser behavior
- Updated existing tests to assert correct field assignment
- Added new fixture `tests/fixtures/rss10_dc_date.xml` and dedicated test case

## Bozo pattern gate

- Valid RSS 1.0 feed with `dc:date`: parses without `bozo = true`, `entry.updated` populated, `entry.published` is None
- 850/850 tests pass