### PR TITLE
fix(core): expose guidislink field and use guid isPermaLink=true as entry.link fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Core, Python, Node.js bindings: expose `entry.guidislink` (`bool`) indicating whether an RSS `<guid>` has `isPermaLink="true"` (or attribute absent, which defaults to true per RSS 2.0 spec); when `guidislink` is true and no `<link>` element is present, `entry.link` now falls back to the guid URL, matching Python feedparser behavior (#179)
 - Core: `dc:date` in RSS 1.0 (RDF) feeds now maps to `entry.updated`/`entry.updated_parsed` instead of `entry.published`/`entry.published_parsed`, matching Python feedparser behavior (#175)
 - Core, Python, Node.js bindings: `Link.length`, `Enclosure.length`, `MediaContent.width`, `MediaContent.height`, `MediaThumbnail.width`, and `MediaThumbnail.height` now return `str` (raw XML attribute value) instead of an integer, matching Python feedparser behavior; non-numeric values are preserved as-is rather than silently dropped (#173)
 - Core: JSON Feed `icon` field now maps to `feed.image` (large timeline image) and `favicon` maps to `feed.icon` (browser favicon), per JSON Feed 1.1 spec; previously the two fields were swapped (#176)

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1001,9 +1001,26 @@ fn parse_item_standard(
             });
         }
         b"guid" => {
+            // isPermaLink defaults to true per RSS 2.0 spec when attribute is absent
+            let is_permalink = find_attribute(attrs, b"isPermaLink")
+                .is_none_or(|v| v.eq_ignore_ascii_case("true"));
             let (text, had_bozo) = read_text(reader, buf, limits)?;
             *bozo |= had_bozo;
-            entry.id = Some(text.into());
+            entry.id = Some(text.clone().into());
+            entry.guidislink = Some(is_permalink);
+            // Use guid as entry.link fallback when it is a permalink and no <link> present
+            if is_permalink && entry.link.is_none() {
+                let resolved = base_ctx.resolve_safe(&text);
+                entry.link = Some(resolved.clone());
+                entry.links.try_push_limited(
+                    Link {
+                        href: resolved.into(),
+                        rel: Some("alternate".into()),
+                        ..Default::default()
+                    },
+                    limits.max_links_per_entry,
+                );
+            }
         }
         b"pubDate" => {
             let text = read_text_str(reader, buf, limits)?;
@@ -1974,6 +1991,91 @@ mod tests {
 
         let feed = parse_rss20(xml).unwrap();
         assert_eq!(feed.entries[0].id.as_deref(), Some("http://example.com/1"));
+        assert_eq!(feed.entries[0].guidislink, Some(true));
+        assert_eq!(
+            feed.entries[0].link.as_deref(),
+            Some("http://example.com/1")
+        );
+    }
+
+    #[test]
+    fn test_parse_rss_guid_not_permalink() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <guid isPermaLink="false">tag:example.com,2024:1</guid>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.entries[0].id.as_deref(),
+            Some("tag:example.com,2024:1")
+        );
+        assert_eq!(feed.entries[0].guidislink, Some(false));
+        assert!(
+            feed.entries[0].link.is_none(),
+            "non-permalink guid must not set entry.link"
+        );
+    }
+
+    #[test]
+    fn test_parse_rss_guid_default_is_permalink() {
+        // Per RSS 2.0 spec, isPermaLink defaults to true when attribute is absent
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <guid>http://example.com/default</guid>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(feed.entries[0].guidislink, Some(true));
+        assert_eq!(
+            feed.entries[0].link.as_deref(),
+            Some("http://example.com/default")
+        );
+    }
+
+    #[test]
+    fn test_parse_rss_guid_permalink_does_not_override_explicit_link() {
+        // When both <link> and <guid isPermaLink="true"> are present,
+        // <link> takes priority for entry.link
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <link>http://example.com/explicit-link</link>
+                    <guid isPermaLink="true">http://example.com/guid</guid>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.entries[0].link.as_deref(),
+            Some("http://example.com/explicit-link")
+        );
+        assert_eq!(feed.entries[0].guidislink, Some(true));
+    }
+
+    #[test]
+    fn test_parse_rss_no_guid_guidislink_is_none() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>No guid here</title>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(feed.entries[0].guidislink.is_none());
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/types/entry.rs
+++ b/crates/feedparser-rs-core/src/types/entry.rs
@@ -102,6 +102,11 @@ pub struct Entry {
     pub slash_comments: Option<u32>,
     /// WFW namespace: comment RSS feed URL (`wfw:commentRss`)
     pub wfw_comment_rss: Option<String>,
+    /// Whether the RSS `<guid>` is a permalink (`isPermaLink` attribute).
+    ///
+    /// `true` when `isPermaLink="true"` or the attribute is absent (RSS 2.0 default).
+    /// `false` when `isPermaLink="false"`. `None` when no `<guid>` element is present.
+    pub guidislink: Option<bool>,
 }
 
 impl Entry {

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -567,6 +567,12 @@ pub struct Entry {
     /// WFW namespace: comment RSS feed URL
     #[napi(js_name = "wfwCommentRss")]
     pub wfw_comment_rss: Option<String>,
+    /// Whether the RSS `<guid>` is a permalink (`isPermaLink` attribute).
+    ///
+    /// `true` when `isPermaLink="true"` or attribute absent (RSS 2.0 default).
+    /// `false` when `isPermaLink="false"`. `null` when no `<guid>` element present.
+    #[napi(js_name = "guidislink")]
+    pub guidislink: Option<bool>,
 }
 
 impl From<CoreEntry> for Entry {
@@ -635,6 +641,7 @@ impl From<CoreEntry> for Entry {
             thr_total: core.thr_total,
             slash_comments: core.slash_comments.map(|n| n.to_string()),
             wfw_comment_rss: core.wfw_comment_rss,
+            guidislink: core.guidislink,
         }
     }
 }

--- a/crates/feedparser-rs-py/src/types/entry.rs
+++ b/crates/feedparser-rs-py/src/types/entry.rs
@@ -275,6 +275,11 @@ impl PyEntry {
     }
 
     #[getter]
+    fn guidislink(&self) -> Option<bool> {
+        self.inner.guidislink
+    }
+
+    #[getter]
     fn dc_date(&self) -> Option<String> {
         self.inner.dc_date.map(|dt| dt.to_rfc3339())
     }
@@ -418,6 +423,7 @@ impl PyEntry {
             "podcast",
             "thr_in_reply_to",
             "thr_total",
+            "guidislink",
         ];
         let mut result = Vec::new();
         for &key in ALL_KEYS {
@@ -943,6 +949,7 @@ impl PyEntry {
                 let value = self.inner.thr_total.map(|n| n.to_string());
                 Ok(value.into_pyobject(py)?.into_any().unbind())
             }
+            "guidislink" => Ok(self.inner.guidislink.into_pyobject(py)?.into_any().unbind()),
             // Check for deprecated field name aliases
             _ => {
                 if let Some(new_names) = ENTRY_FIELD_MAP.get(key) {


### PR DESCRIPTION
## Summary

- Adds `entry.guidislink` (`bool`) to core, Python, and Node.js bindings — `True` when `isPermaLink="true"` or attribute absent (RSS 2.0 default is `true`), `False` when `isPermaLink="false"`, `None`/`null` when no `<guid>` element is present
- When `guidislink` is `true` and no `<link>` element is present, `entry.link` now falls back to the guid URL, matching Python feedparser behavior
- Existing `<link>` always takes priority over guid fallback

Fixes #179.

## Test plan

- [x] `test_parse_rss_with_guid_permalink` — updated to assert `guidislink=true` and `entry.link` set from guid
- [x] `test_parse_rss_guid_not_permalink` — `isPermaLink="false"` sets `guidislink=false`, no link fallback
- [x] `test_parse_rss_guid_default_is_permalink` — absent attribute defaults to `guidislink=true` and sets link
- [x] `test_parse_rss_guid_permalink_does_not_override_explicit_link` — explicit `<link>` takes priority
- [x] `test_parse_rss_no_guid_guidislink_is_none` — `guidislink` is `None` when no guid present
- [x] `cargo nextest run` — 847 tests passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo +nightly fmt --check` — no diffs

## Bozo pattern gate

- Valid feeds with `<guid isPermaLink="true">` do NOT set `bozo=true`
- Feeds without `<guid>` are unaffected