### PR TITLE
fix(core): recognize syndication namespace with both sy: and syn: prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Core: syndication namespace elements (`updatePeriod`, `updateFrequency`, `updateBase`) are now recognized with both `sy:` and `syn:` prefixes; previously only `syn:` was recognized, causing `feed.syndication` to return `None` for feeds using the more common `sy:` prefix (#191)
 - Core, Python, Node.js bindings: expose `entry.guidislink` (`bool`) indicating whether an RSS `<guid>` has `isPermaLink="true"` (or attribute absent, which defaults to true per RSS 2.0 spec); when `guidislink` is true and no `<link>` element is present, `entry.link` now falls back to the guid URL, matching Python feedparser behavior (#179)
 - Core: `entry.podcast.transcript` and `entry.podcast.person` are now populated from the same data as `entry.podcast_transcripts` and `entry.podcast_persons`; `entry.podcast` is now non-None whenever any Podcast 2.0 namespace element (transcript, person, soundbite, or chapters) is present (#183)
 - Core: `<media:content>` elements nested inside a `<media:group>` wrapper are now parsed into `entry.media_content` (and `entry.media_thumbnail` for `<media:thumbnail>`) for both RSS and Atom feeds; previously only top-level `<media:content>` elements were recognized (#184)

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -213,16 +213,20 @@ pub fn is_content_tag(name: &[u8]) -> Option<&str> {
 
 /// Check if element is a Syndication namespaced tag
 ///
+/// Recognizes both `sy:` (RSS 1.0 spec convention) and `syn:` prefixes,
+/// as both map to `http://purl.org/rss/1.0/modules/syndication/`.
+///
 /// # Examples
 ///
 /// ```ignore
 /// assert_eq!(is_syn_tag(b"syn:updatePeriod"), Some("updatePeriod"));
+/// assert_eq!(is_syn_tag(b"sy:updatePeriod"), Some("updatePeriod"));
 /// assert_eq!(is_syn_tag(b"syn:updateFrequency"), Some("updateFrequency"));
 /// assert_eq!(is_syn_tag(b"dc:creator"), None);
 /// ```
 #[inline]
 pub fn is_syn_tag(name: &[u8]) -> Option<&str> {
-    extract_ns_local_name(name, b"syn:")
+    extract_ns_local_name(name, b"sy:").or_else(|| extract_ns_local_name(name, b"syn:"))
 }
 
 /// Check if element is a Media RSS namespaced tag

--- a/crates/feedparser-rs-core/src/parser/rss10.rs
+++ b/crates/feedparser-rs-core/src/parser/rss10.rs
@@ -743,6 +743,34 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_rss10_with_syndication_sy_prefix() {
+        let xml = br#"<?xml version="1.0"?>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                 xmlns="http://purl.org/rss/1.0/"
+                 xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
+            <channel rdf:about="http://example.com/">
+                <title>Test</title>
+                <link>http://example.com</link>
+                <description>Test</description>
+                <sy:updatePeriod>daily</sy:updatePeriod>
+                <sy:updateFrequency>1</sy:updateFrequency>
+                <sy:updateBase>2024-06-01T00:00:00Z</sy:updateBase>
+            </channel>
+        </rdf:RDF>"#;
+
+        let feed = parse_rss10(xml).unwrap();
+        assert!(feed.feed.syndication.is_some());
+
+        let syn = feed.feed.syndication.as_ref().unwrap();
+        assert_eq!(
+            syn.update_period,
+            Some(crate::namespace::syndication::UpdatePeriod::Daily)
+        );
+        assert_eq!(syn.update_frequency, Some(1));
+        assert_eq!(syn.update_base.as_deref(), Some("2024-06-01T00:00:00Z"));
+    }
+
+    #[test]
     fn test_rss10_namespaces_on_rdf_root() {
         let xml = br#"<?xml version="1.0"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"


### PR DESCRIPTION
## Summary

- `is_syn_tag()` now recognizes both `sy:` and `syn:` prefixes for syndication namespace elements
- Both prefixes map to `http://purl.org/rss/1.0/modules/syndication/` and must work identically per XML namespace rules
- Added integration test for `sy:` prefix in RSS 1.0 parser

## Root Cause

`is_syn_tag()` in `parser/common.rs` only matched the `syn:` prefix via `extract_ns_local_name(name, b"syn:")`. Feeds using the `sy:` prefix (which is the convention used in RSS 1.0 spec examples and many real-world feeds) returned `None` for `feed.syndication`.

## Fix

Updated `is_syn_tag()` to check `sy:` first (spec convention), then fall back to `syn:`:

```rust
pub fn is_syn_tag(name: &[u8]) -> Option<&str> {
    extract_ns_local_name(name, b"sy:").or_else(|| extract_ns_local_name(name, b"syn:"))
}
```

## Test plan

- [x] New test `test_parse_rss10_with_syndication_sy_prefix` verifies `sy:` prefix works
- [x] Existing test `test_parse_rss10_with_syndication` still passes for `syn:` prefix
- [x] `cargo nextest run` — 865 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo deny check` — clean
- [x] Bozo pattern gate: valid feed with `sy:` prefix does NOT produce `bozo = true`

Closes #191