### PR TITLE
fix(core): add RSS enclosure to entry.links with rel=enclosure (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Core: RSS `<enclosure>` elements are now added to both `entry.enclosures` and `entry.links` (with `rel='enclosure'`), matching Python feedparser behavior (#192)
 - Core: syndication namespace elements (`updatePeriod`, `updateFrequency`, `updateBase`) are now recognized with both `sy:` and `syn:` prefixes; previously only `syn:` was recognized, causing `feed.syndication` to return `None` for feeds using the more common `sy:` prefix (#191)
 - Core, Python, Node.js bindings: GeoRSS location is now exposed as `entry.where` / `entry.where_` (was `entry.geo`), matching Python feedparser field name; coordinates now follow GeoJSON order `(lon, lat)` (was `(lat, lon)`); type names use GeoJSON capitalization (`Point`, `LineString`, `Polygon`); Python and Node.js bindings return a dict `{'type': 'Point', 'coordinates': (lon, lat)}` instead of a custom GeoLocation object (#185)
 - Core, Python, Node.js bindings: `MediaContent` now exposes `bitrate`, `lang`, `channels`, `codec`, `expression`, `isdefault`, `samplingrate` attributes; `duration` changed from integer to raw string matching Python feedparser behavior (#190)

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -921,6 +921,16 @@ fn parse_item(
                     b"enclosure" => {
                         if let Some(mut enclosure) = parse_enclosure(&attrs, limits) {
                             enclosure.url = base_ctx.resolve_safe(&enclosure.url).into();
+                            let link = Link {
+                                href: enclosure.url.clone(),
+                                rel: Some("enclosure".into()),
+                                link_type: enclosure.enclosure_type.clone(),
+                                length: enclosure.length.clone(),
+                                ..Link::default()
+                            };
+                            entry
+                                .links
+                                .try_push_limited(link, limits.max_links_per_entry);
                             entry
                                 .enclosures
                                 .try_push_limited(enclosure, limits.max_enclosures);
@@ -2038,6 +2048,36 @@ mod tests {
             feed.entries[0].enclosures[0].enclosure_type.as_deref(),
             Some("audio/mpeg")
         );
+    }
+
+    #[test]
+    fn test_enclosure_also_in_links() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <link>http://example.com/ep1</link>
+                    <enclosure url="http://example.com/audio.mp3"
+                               length="12345678"
+                               type="audio/mpeg"/>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        let entry = &feed.entries[0];
+
+        assert_eq!(entry.enclosures.len(), 1);
+
+        let enc_link = entry
+            .links
+            .iter()
+            .find(|l| l.rel.as_deref() == Some("enclosure"));
+        assert!(enc_link.is_some(), "enclosure must appear in entry.links");
+        let enc_link = enc_link.unwrap();
+        assert_eq!(enc_link.href.as_str(), "http://example.com/audio.mp3");
+        assert_eq!(enc_link.link_type.as_deref(), Some("audio/mpeg"));
+        assert_eq!(enc_link.length.as_deref(), Some("12345678"));
     }
 
     #[test]

--- a/tests/fixtures/rss_enclosure_links.xml
+++ b/tests/fixtures/rss_enclosure_links.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Enclosure Feed</title>
+    <link>http://example.com/</link>
+    <item>
+      <title>Episode 1</title>
+      <link>http://example.com/ep1</link>
+      <enclosure url="http://example.com/audio.mp3" length="12345678" type="audio/mpeg"/>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- When an RSS `<enclosure>` is parsed, it is now added to both `entry.enclosures` (existing) and `entry.links` with `rel='enclosure'`, matching Python feedparser behavior
- Uses `try_push_limited` to respect `max_links_per_entry` DoS protection limit
- Adds test fixture `tests/fixtures/rss_enclosure_links.xml` and unit test `test_enclosure_also_in_links`

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 866 tests pass
- [x] New test verifies enclosure appears in both `entry.enclosures` and `entry.links` with correct `rel`, `href`, `type`, and `length`
- [x] Valid feeds do not trigger `bozo = true`

Closes #192