### PR TITLE
fix(core): rename entry.source.link to href, add missing Atom source fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `entry.source.link` renamed to `entry.source.href` in core Rust type and Node.js bindings for Python feedparser API compatibility; Python binding retains `source.link` as an alias for `source.href` (#240)
+
+### Added
+
+- Core, Python, Node.js bindings: `entry.source` now exposes `links` (all link elements), `updated`/`updated_parsed`, `rights`, and `guidislink` fields for Atom `<source>` elements, matching Python feedparser (#242, #214)
+- Core: `entry.source.guidislink` is `Some(true)` when the Atom `<source>` `<id>` looks like a URL and no explicit `<link>` is present; `Some(false)` when an explicit `<link>` is present or the id is not a URL; `None` for RSS sources
+
 ## [0.5.0] - 2026-03-24
 
 ### Fixed

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -830,8 +830,14 @@ fn parse_atom_source(
     depth: &mut usize,
 ) -> Result<Source> {
     let mut title = None;
-    let mut link = None;
+    let mut href = None;
+    let mut first_link_href: Option<String> = None;
     let mut id = None;
+    let mut links = Vec::new();
+    let mut updated = None;
+    let mut updated_str = None;
+    let mut rights = None;
+    let mut has_explicit_link = false;
 
     loop {
         match reader.read_event_into(buf) {
@@ -849,18 +855,33 @@ fn parse_atom_source(
                 match element.name().as_ref() {
                     b"title" if !is_empty => title = Some(read_text_str(reader, buf, limits)?),
                     b"link" => {
-                        if let Some(l) = Link::from_attributes(
+                        if let Some(link) = Link::from_attributes(
                             element.attributes().flatten(),
                             limits.max_attribute_length,
-                        ) && link.is_none()
-                        {
-                            link = Some(l.href.to_string());
+                        ) {
+                            // Track first alternate rel for href; fall back to first link seen.
+                            if link.rel.as_deref() == Some("alternate") && href.is_none() {
+                                href = Some(link.href.to_string());
+                            }
+                            if first_link_href.is_none() {
+                                first_link_href = Some(link.href.to_string());
+                            }
+                            has_explicit_link = true;
+                            links.push(link);
                         }
                         if !is_empty {
                             skip_to_end(reader, buf, b"link")?;
                         }
                     }
                     b"id" if !is_empty => id = Some(read_text_str(reader, buf, limits)?),
+                    b"updated" | b"modified" if !is_empty => {
+                        let text = read_text_str(reader, buf, limits)?;
+                        updated = parse_date(&text);
+                        updated_str = Some(text);
+                    }
+                    b"rights" if !is_empty => {
+                        rights = Some(read_text_str(reader, buf, limits)?);
+                    }
                     _ if !is_empty => skip_element(reader, buf, limits, *depth)?,
                     _ => {}
                 }
@@ -874,7 +895,37 @@ fn parse_atom_source(
         buf.clear();
     }
 
-    Ok(Source { title, link, id })
+    // Fall back to first link of any rel if no alternate was found
+    if href.is_none() {
+        href = first_link_href;
+    }
+
+    // Compute guidislink per Python feedparser semantics:
+    // - None when no <id> present
+    // - Some(true) when <id> looks like a URL and no explicit <link> present
+    // - Some(false) otherwise
+    let guidislink = id.as_deref().map(|id_val| {
+        let id_is_url = id_val.starts_with("http://")
+            || id_val.starts_with("https://")
+            || id_val.starts_with("ftp://");
+        id_is_url && !has_explicit_link
+    });
+
+    // When guidislink is true, populate href from the id value (matching Python feedparser)
+    if guidislink == Some(true) {
+        href.clone_from(&id);
+    }
+
+    Ok(Source {
+        title,
+        href,
+        id,
+        links,
+        updated,
+        updated_str,
+        rights,
+        guidislink,
+    })
 }
 
 #[cfg(test)]
@@ -1144,7 +1195,142 @@ mod tests {
         let feed = parse_atom10(xml).unwrap();
         let source = feed.entries[0].source.as_ref().unwrap();
         assert_eq!(source.id.as_deref(), Some("source-id-here"));
-        assert_eq!(source.link.as_deref(), Some("http://x.com/"));
+        assert_eq!(source.href.as_deref(), Some("http://x.com/"));
+    }
+
+    #[test]
+    fn test_parse_atom_source_updated() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source Feed</title>
+                    <id>urn:source</id>
+                    <updated>2025-01-12T00:00:00Z</updated>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert!(source.updated.is_some());
+        assert_eq!(source.updated_str.as_deref(), Some("2025-01-12T00:00:00Z"));
+    }
+
+    #[test]
+    fn test_parse_atom_source_rights() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source Feed</title>
+                    <rights>Copyright 2025</rights>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert_eq!(source.rights.as_deref(), Some("Copyright 2025"));
+    }
+
+    #[test]
+    fn test_parse_atom_source_links() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source</title>
+                    <link href="http://a.com/" rel="alternate"/>
+                    <link href="http://a.com/feed" rel="self"/>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert_eq!(source.links.len(), 2);
+        assert_eq!(source.href.as_deref(), Some("http://a.com/"));
+    }
+
+    #[test]
+    fn test_parse_atom_source_guidislink_true() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source</title>
+                    <id>http://example.com/feed</id>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert_eq!(source.guidislink, Some(true));
+        assert_eq!(source.href.as_deref(), Some("http://example.com/feed"));
+    }
+
+    #[test]
+    fn test_parse_atom_source_guidislink_false_with_link() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source</title>
+                    <id>http://example.com/feed</id>
+                    <link href="http://other.com/"/>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert_eq!(source.guidislink, Some(false));
+        assert_eq!(source.href.as_deref(), Some("http://other.com/"));
+    }
+
+    #[test]
+    fn test_parse_atom_source_guidislink_urn_id() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source</title>
+                    <id>urn:uuid:60a76c80-d399-11d9</id>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert_eq!(source.guidislink, Some(false));
+        assert!(source.href.is_none());
+    }
+
+    #[test]
+    fn test_parse_atom_source_no_id() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>e1</id>
+                <source>
+                    <title>Source</title>
+                    <link href="http://a.com/"/>
+                </source>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert!(source.guidislink.is_none());
+        assert_eq!(source.href.as_deref(), Some("http://a.com/"));
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1747,7 +1747,16 @@ fn parse_source(
         Some(title_str.to_owned())
     };
 
-    Ok(Source { title, link, id })
+    Ok(Source {
+        title,
+        href: link,
+        id,
+        links: Vec::new(),
+        updated: None,
+        updated_str: None,
+        rights: None,
+        guidislink: None,
+    })
 }
 
 /// Parse iTunes owner from <itunes:owner> element
@@ -2402,7 +2411,25 @@ mod tests {
         assert!(feed.entries[0].source.is_some());
         let source = feed.entries[0].source.as_ref().unwrap();
         assert_eq!(source.title.as_deref(), Some("Source Feed"));
-        assert_eq!(source.link.as_deref(), Some("http://source.example.com"));
+        assert_eq!(source.href.as_deref(), Some("http://source.example.com"));
+    }
+
+    #[test]
+    fn test_parse_rss_source_no_guidislink() {
+        // RSS <source> has no <id> child, so guidislink and links are always empty/None
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <source url="http://source.example.com">Source Feed</source>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        let source = feed.entries[0].source.as_ref().unwrap();
+        assert!(source.guidislink.is_none());
+        assert!(source.links.is_empty());
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/types/common.rs
+++ b/crates/feedparser-rs-core/src/types/common.rs
@@ -718,10 +718,24 @@ pub struct Generator {
 pub struct Source {
     /// Source title
     pub title: Option<String>,
-    /// Source link
-    pub link: Option<String>,
-    /// Source ID
+    /// Primary source URL (renamed from `link` for Python feedparser API compatibility)
+    pub href: Option<String>,
+    /// Source unique identifier
     pub id: Option<String>,
+    /// All links from the source element
+    pub links: Vec<Link>,
+    /// Last update date (Atom `<updated>`)
+    pub updated: Option<DateTime<Utc>>,
+    /// Original update date string (timezone preserved)
+    pub updated_str: Option<String>,
+    /// Rights/copyright statement (Atom `<rights>`)
+    pub rights: Option<String>,
+    /// Whether `<id>` was used as the link.
+    ///
+    /// `Some(true)` when `<id>` looks like a URL and no explicit `<link>` was present.
+    /// `Some(false)` when `<id>` is present but a `<link>` was also present, or `<id>` is not a URL.
+    /// `None` for RSS sources (RSS `<source>` has no `<id>`).
+    pub guidislink: Option<bool>,
 }
 
 /// Media RSS thumbnail

--- a/crates/feedparser-rs-core/tests/integration_tests.rs
+++ b/crates/feedparser-rs-core/tests/integration_tests.rs
@@ -653,7 +653,7 @@ fn test_rss_source_element_title_and_link() {
     let entry = &feed.entries[0];
     let source = entry.source.as_ref().expect("entry must have source");
     assert_eq!(source.title.as_deref(), Some("Other Feed Name"));
-    assert_eq!(source.link.as_deref(), Some("https://otherfeed.com/rss"));
+    assert_eq!(source.href.as_deref(), Some("https://otherfeed.com/rss"));
 }
 
 // Regression tests for issue #152: whitespace around XML entities must be preserved.

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -866,18 +866,30 @@ impl From<CoreGenerator> for Generator {
 pub struct Source {
     /// Source title
     pub title: Option<String>,
-    /// Source link
-    pub link: Option<String>,
+    /// Primary source URL (renamed from `link` for Python feedparser API compatibility)
+    pub href: Option<String>,
     /// Source ID
     pub id: Option<String>,
+    /// All links from the source element
+    pub links: Vec<Link>,
+    /// Last update date string (Atom `<updated>`, RFC 3339)
+    pub updated: Option<String>,
+    /// Rights/copyright statement (Atom `<rights>`)
+    pub rights: Option<String>,
+    /// Whether `<id>` was used as the link
+    pub guidislink: Option<bool>,
 }
 
 impl From<CoreSource> for Source {
     fn from(core: CoreSource) -> Self {
         Self {
             title: core.title,
-            link: core.link,
+            href: core.href,
             id: core.id.map(|s| s.to_string()),
+            links: core.links.into_iter().map(Link::from).collect(),
+            updated: core.updated_str,
+            rights: core.rights,
+            guidislink: core.guidislink,
         }
     }
 }

--- a/crates/feedparser-rs-py/src/types/common.rs
+++ b/crates/feedparser-rs-py/src/types/common.rs
@@ -463,14 +463,52 @@ impl PySource {
         self.inner.title.as_deref()
     }
 
+    /// Primary source URL (Python feedparser API name).
+    #[getter]
+    fn href(&self) -> Option<&str> {
+        self.inner.href.as_deref()
+    }
+
+    /// Alias for `href` for backward compatibility.
     #[getter]
     fn link(&self) -> Option<&str> {
-        self.inner.link.as_deref()
+        self.inner.href.as_deref()
     }
 
     #[getter]
     fn id(&self) -> Option<&str> {
         self.inner.id.as_deref()
+    }
+
+    #[getter]
+    fn links(&self) -> Vec<PyLink> {
+        self.inner
+            .links
+            .iter()
+            .map(|l| PyLink::from_core(l.clone()))
+            .collect()
+    }
+
+    /// Raw updated date string (timezone preserved).
+    #[getter]
+    fn updated(&self) -> Option<&str> {
+        self.inner.updated_str.as_deref()
+    }
+
+    /// Parsed updated date as `time.struct_time`.
+    #[getter]
+    fn updated_parsed(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        optional_datetime_to_struct_time(py, &self.inner.updated)
+    }
+
+    #[getter]
+    fn rights(&self) -> Option<&str> {
+        self.inner.rights.as_deref()
+    }
+
+    #[getter]
+    fn guidislink(&self) -> Option<bool> {
+        self.inner.guidislink
     }
 
     fn __repr__(&self) -> String {
@@ -481,11 +519,65 @@ impl PySource {
         }
     }
 
-    fn __getitem__(&self, key: &str) -> PyResult<Option<String>> {
+    fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
         match key {
-            "title" => Ok(self.inner.title.as_deref().map(str::to_owned)),
-            "link" => Ok(self.inner.link.as_deref().map(str::to_owned)),
-            "id" => Ok(self.inner.id.as_deref().map(str::to_owned)),
+            "title" => Ok(self
+                .inner
+                .title
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "href" => Ok(self
+                .inner
+                .href
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            // `link` is an alias for `href` for Python feedparser dict-style compat
+            "link" => Ok(self
+                .inner
+                .href
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "id" => Ok(self
+                .inner
+                .id
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "links" => {
+                let py_links: Vec<PyLink> = self
+                    .inner
+                    .links
+                    .iter()
+                    .map(|l| PyLink::from_core(l.clone()))
+                    .collect();
+                Ok(py_links.into_pyobject(py)?.into_any().unbind())
+            }
+            "updated" => Ok(self
+                .inner
+                .updated_str
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "updated_parsed" => Ok(optional_datetime_to_struct_time(py, &self.inner.updated)?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "rights" => Ok(self
+                .inner
+                .rights
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "guidislink" => Ok(self.inner.guidislink.into_pyobject(py)?.into_any().unbind()),
             _ => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
         }
     }


### PR DESCRIPTION
## Summary

- Rename `Source.link` → `Source.href` for Python feedparser API compatibility (#240)
- Add `links`, `updated`, `updated_parsed`, `rights`, `guidislink` fields to Atom `<source>` (#242, #214)
- Update Python binding (PySource) with all new fields; keep `link` as alias for `href`
- Update Node.js binding Source struct with renamed and new fields
- 8 new tests covering guidislink truth table, updated, rights, links vec, RSS defaults

## Breaking changes

- `Source.link` field renamed to `Source.href` in Rust core and Node.js binding
- Python binding retains `link` as a getter alias and `__getitem__` alias — no Python API break

## Bozo pattern

- Invalid dates in Atom `<source><updated>` store raw string, parsed `DateTime` is `None` — no panic

## Test plan

- [x] `cargo nextest run` — 884 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo deny check` — clean

Closes #240, #242, #214