### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-03-24
+
 ### Fixed
 - Core: RSS `<enclosure>` elements are now added to both `entry.enclosures` and `entry.links` (with `rel='enclosure'`), matching Python feedparser behavior (#192)
 - Core: syndication namespace elements (`updatePeriod`, `updateFrequency`, `updateBase`) are now recognized with both `sy:` and `syn:` prefixes; previously only `syn:` was recognized, causing `feed.syndication` to return `None` for feeds using the more common `sy:` prefix (#191)
@@ -337,7 +339,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage
 - Documentation with examples
 
-[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.8...HEAD
+[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.8...v0.5.0
 [0.4.8]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.5...v0.4.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "feedparser-rs"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "ammonia",
  "chrono",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-node"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "feedparser-rs",
  "napi",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-py"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "feedparser-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.8"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["bug-ops"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs = "0.4.8"
+feedparser-rs = "0.5.0"
 ```
 
 > [!IMPORTANT]
@@ -187,7 +187,7 @@ To disable HTTP support and reduce dependencies:
 
 ```toml
 [dependencies]
-feedparser-rs = { version = "0.4.8", default-features = false }
+feedparser-rs = { version = "0.5.0", default-features = false }
 ```
 
 ## Workspace Structure

--- a/crates/feedparser-rs-node/package.json
+++ b/crates/feedparser-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedparser-rs",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "High-performance RSS/Atom/JSON Feed parser for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/feedparser-rs-py/pyproject.toml
+++ b/crates/feedparser-rs-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feedparser-rs"
-version = "0.4.8"
+version = "0.5.0"
 description = "High-performance RSS/Atom/JSON Feed parser with feedparser-compatible API"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump version from 0.4.8 to 0.5.0
- Update CHANGELOG.md with release notes for v0.5.0
- Refresh README and documentation with new version

## Updated files

- `Cargo.toml` — workspace version bump
- `Cargo.lock` — dependency resolution
- `CHANGELOG.md` — v0.5.0 section added with date
- `README.md` — version references updated
- `crates/feedparser-rs-py/pyproject.toml` — version bump
- `crates/feedparser-rs-node/package.json` — version bump

## Checklist

- [x] Version updated in all manifests (Cargo.toml, pyproject.toml, package.json)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass (876 tests, no clippy warnings)
- [ ] Ready for tagging after merge