### PR TITLE
fix(core): syndication module in RSS 2.0 and update_frequency as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Core: syndication module (`syn:`/`sy:` namespace) is now parsed in RSS 2.0 feeds; previously only RSS 1.0 feeds were supported — RSS 2.0 feeds with `<syn:updatePeriod>` etc. returned `feed.syndication = None` (#237)
+- Core: `syn:updateFrequency` / `sy:updateFrequency` now returns the raw string value (e.g. `"2"`) instead of an integer, matching Python feedparser behavior (#268, #220)
+
 - Core, Python, Node.js bindings: Atom `<source><link href="..."/>` now populates `entry.source.link` (new field); `entry.source.href` remains for RSS `<source url="...">` only (#262)
 - Core, Python, Node.js bindings: Atom `<source><author>` is now exposed as `entry.source.author` flat string in `"Name (email)"` format (#262)
 - Core, Python, Node.js bindings: Atom `<content src="...">` (out-of-line content per RFC 4287 §4.1.3.2) is now parsed — `content.src` is set to the URL, `content.value` is empty string, `content.type` is set from the `type` attribute (#252)

--- a/crates/feedparser-rs-core/src/namespace/syndication.rs
+++ b/crates/feedparser-rs-core/src/namespace/syndication.rs
@@ -65,7 +65,7 @@ pub struct SyndicationMeta {
     /// Update period (hourly, daily, weekly, monthly, yearly)
     pub update_period: Option<UpdatePeriod>,
     /// Number of times updated per period
-    pub update_frequency: Option<u32>,
+    pub update_frequency: Option<String>,
     /// Base date for update schedule (ISO 8601)
     pub update_base: Option<String>,
 }
@@ -90,12 +90,12 @@ pub fn handle_feed_element(element: &str, text: &str, feed: &mut FeedMeta) {
             }
         }
         "updateFrequency" => {
-            if let Ok(freq) = text.parse::<u32>() {
+            if !text.is_empty() {
                 if feed.syndication.is_none() {
                     feed.syndication = Some(Box::new(SyndicationMeta::default()));
                 }
                 if let Some(syn) = &mut feed.syndication {
-                    syn.update_frequency = Some(freq);
+                    syn.update_frequency = Some(text.to_string());
                 }
             }
         }
@@ -162,7 +162,7 @@ mod tests {
 
         assert!(feed.syndication.is_some());
         let syn = feed.syndication.as_ref().unwrap();
-        assert_eq!(syn.update_frequency, Some(2));
+        assert_eq!(syn.update_frequency, Some("2".to_string()));
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
 
         let syn = feed.syndication.as_ref().unwrap();
         assert_eq!(syn.update_period, Some(UpdatePeriod::Hourly));
-        assert_eq!(syn.update_frequency, Some(1));
+        assert_eq!(syn.update_frequency, Some("1".to_string()));
         assert_eq!(syn.update_base.as_deref(), Some("2024-01-01T00:00:00Z"));
     }
 
@@ -196,8 +196,9 @@ mod tests {
 
         handle_feed_element("updateFrequency", "not-a-number", &mut feed);
 
-        // Should not create syndication metadata for invalid input
-        assert!(feed.syndication.is_none());
+        // Raw string is stored as-is (matches Python feedparser behavior)
+        let syn = feed.syndication.as_ref().unwrap();
+        assert_eq!(syn.update_frequency, Some("not-a-number".to_string()));
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -3,7 +3,7 @@
 use crate::{
     ParserLimits,
     error::{FeedError, Result},
-    namespace::{content, dublin_core, georss, media_rss, slash, threading},
+    namespace::{content, dublin_core, georss, media_rss, slash, syndication, threading},
     types::{
         Enclosure, Entry, FeedVersion, Image, ItunesCategory, ItunesEntryMeta, ItunesFeedMeta,
         ItunesOwner, Link, MediaContent, MediaThumbnail, ParsedFeed, Person, PodcastChapters,
@@ -21,7 +21,7 @@ use quick_xml::{Reader, events::Event};
 use super::common::{
     EVENT_BUFFER_CAPACITY, LimitedCollectionExt, check_depth, extract_namespaces, extract_xml_lang,
     init_feed, is_content_tag, is_dc_tag, is_georss_tag, is_itunes_tag, is_media_tag, is_slash_tag,
-    is_thr_tag, is_wfw_tag, read_text, read_text_str, skip_element,
+    is_syn_tag, is_thr_tag, is_wfw_tag, read_text, read_text_str, skip_element,
 };
 
 /// Error message for malformed XML attributes (shared constant)
@@ -871,6 +871,13 @@ fn parse_channel_namespace(
         // Atom Threading Extensions at channel level — recognize and skip
         if !is_empty {
             skip_element(reader, buf, limits, depth)?;
+        }
+        Ok(true)
+    } else if let Some(syn_element) = is_syn_tag(tag) {
+        if !is_empty {
+            let syn_elem = syn_element.to_string();
+            let text = read_text_str(reader, buf, limits)?;
+            syndication::handle_feed_element(&syn_elem, &text, &mut feed.feed);
         }
         Ok(true)
     } else {
@@ -3905,5 +3912,55 @@ mod tests {
             15,
             "entry.updated must use dc:date, not pubDate"
         );
+    }
+
+    #[test]
+    fn test_parse_rss2_with_syndication_syn_prefix() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:syn="http://purl.org/rss/1.0/modules/syndication/">
+          <channel>
+            <title>Test</title>
+            <link>http://example.com</link>
+            <syn:updatePeriod>hourly</syn:updatePeriod>
+            <syn:updateFrequency>2</syn:updateFrequency>
+            <syn:updateBase>2024-01-01T00:00:00Z</syn:updateBase>
+          </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(feed.feed.syndication.is_some());
+
+        let syn = feed.feed.syndication.as_ref().unwrap();
+        assert_eq!(
+            syn.update_period,
+            Some(crate::namespace::syndication::UpdatePeriod::Hourly)
+        );
+        assert_eq!(syn.update_frequency, Some("2".to_string()));
+        assert_eq!(syn.update_base.as_deref(), Some("2024-01-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn test_parse_rss2_with_syndication_sy_prefix() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
+          <channel>
+            <title>Test</title>
+            <link>http://example.com</link>
+            <sy:updatePeriod>daily</sy:updatePeriod>
+            <sy:updateFrequency>1</sy:updateFrequency>
+            <sy:updateBase>2024-06-01T00:00:00Z</sy:updateBase>
+          </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(feed.feed.syndication.is_some());
+
+        let syn = feed.feed.syndication.as_ref().unwrap();
+        assert_eq!(
+            syn.update_period,
+            Some(crate::namespace::syndication::UpdatePeriod::Daily)
+        );
+        assert_eq!(syn.update_frequency, Some("1".to_string()));
+        assert_eq!(syn.update_base.as_deref(), Some("2024-06-01T00:00:00Z"));
     }
 }

--- a/crates/feedparser-rs-core/src/parser/rss10.rs
+++ b/crates/feedparser-rs-core/src/parser/rss10.rs
@@ -738,7 +738,7 @@ mod tests {
             syn.update_period,
             Some(crate::namespace::syndication::UpdatePeriod::Hourly)
         );
-        assert_eq!(syn.update_frequency, Some(2));
+        assert_eq!(syn.update_frequency, Some("2".to_string()));
         assert_eq!(syn.update_base.as_deref(), Some("2024-01-01T00:00:00Z"));
     }
 
@@ -766,7 +766,7 @@ mod tests {
             syn.update_period,
             Some(crate::namespace::syndication::UpdatePeriod::Daily)
         );
-        assert_eq!(syn.update_frequency, Some(1));
+        assert_eq!(syn.update_frequency, Some("1".to_string()));
         assert_eq!(syn.update_base.as_deref(), Some("2024-06-01T00:00:00Z"));
     }
 

--- a/crates/feedparser-rs-core/tests/test_rss10.rs
+++ b/crates/feedparser-rs-core/tests/test_rss10.rs
@@ -510,7 +510,7 @@ fn test_rss10_with_syndication_module() {
     // Check update frequency (2 times per period)
     assert_eq!(
         syn.update_frequency,
-        Some(2),
+        Some("2".to_string()),
         "Update frequency should be 2"
     );
 

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -288,7 +288,7 @@ pub struct SyndicationMeta {
     pub update_period: Option<String>,
     /// Number of times updated per period
     #[napi(js_name = "updateFrequency")]
-    pub update_frequency: Option<u32>,
+    pub update_frequency: Option<String>,
     /// Base date for update schedule (ISO 8601)
     #[napi(js_name = "updateBase")]
     pub update_base: Option<String>,
@@ -298,7 +298,7 @@ impl From<CoreSyndicationMeta> for SyndicationMeta {
     fn from(core: CoreSyndicationMeta) -> Self {
         Self {
             update_period: core.update_period.map(|p| p.as_str().to_string()),
-            update_frequency: core.update_frequency,
+            update_frequency: core.update_frequency.clone(),
             update_base: core.update_base,
         }
     }

--- a/crates/feedparser-rs-py/src/types/syndication.rs
+++ b/crates/feedparser-rs-py/src/types/syndication.rs
@@ -24,8 +24,8 @@ impl PySyndicationMeta {
 
     /// Number of times updated per period
     #[getter]
-    fn update_frequency(&self) -> Option<u32> {
-        self.inner.update_frequency
+    fn update_frequency(&self) -> Option<&str> {
+        self.inner.update_frequency.as_deref()
     }
 
     /// Base date for update schedule (ISO 8601)
@@ -38,7 +38,7 @@ impl PySyndicationMeta {
         format!(
             "SyndicationMeta(update_period={:?}, update_frequency={:?}, update_base={:?})",
             self.inner.update_period.as_ref().map(|p| p.as_str()),
-            self.inner.update_frequency,
+            self.inner.update_frequency.as_deref(),
             self.inner.update_base.as_deref()
         )
     }

--- a/crates/feedparser-rs-py/tests/test_syndication.py
+++ b/crates/feedparser-rs-py/tests/test_syndication.py
@@ -34,7 +34,7 @@ def test_syndication_update_frequency():
 
     d = feedparser_rs.parse(feed_xml)
     assert d.feed.syndication is not None
-    assert d.feed.syndication.update_frequency == 2
+    assert d.feed.syndication.update_frequency == "2"
 
 
 def test_syndication_update_base():
@@ -74,7 +74,7 @@ def test_syndication_complete():
     syn = d.feed.syndication
     assert syn is not None
     assert syn.update_period == "hourly"
-    assert syn.update_frequency == 1
+    assert syn.update_frequency == "1"
     assert syn.update_base == "2024-01-01T00:00:00Z"
 
 


### PR DESCRIPTION
## Summary

- Adds syndication namespace (`syn:`/`sy:`) parsing to the RSS 2.0 parser — previously only RSS 1.0 feeds were supported; RSS 2.0 feeds with `<syn:updatePeriod>` etc. silently returned `feed.syndication = None` (#237)
- Changes `update_frequency` field type from integer to `String` in `SyndicationInfo`, matching Python feedparser behavior which returns the raw string value (e.g. `"2"` not `2`) (#268, #220)

## Fixes

Closes #237
Closes #268
Closes #220

## Test plan

- [x] RSS 2.0 feed with `<syn:updatePeriod>` and `<syn:updateFrequency>` → `feed.syndication` is populated
- [x] RSS 1.0 feed with `<sy:updateFrequency>` → value returned as string `"2"`, not int `2`
- [x] `cargo +nightly fmt --check` — pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — pass
- [x] `cargo nextest run` — 901 tests pass
- [x] `cargo deny check` — pass

## Bozo pattern

- Valid RSS 2.0 feeds with syndication namespace: `bozo = false`, `feed.syndication` populated
- Feeds without syndication namespace: `bozo = false`, `feed.syndication = None` (unchanged)