### PR TITLE
fix(core): guidislink after id promotion, dc:creator in Atom, RSS 0.91/0.92 version strings (#285, #278, #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: Atom `entry.guidislink` is now `Some(false)` when `<id>` is present (was always `None`), matching Python feedparser behavior (#256)
 - Python: all nested struct types (Image, Enclosure, Link, Person, TextConstruct, Generator, Tag, Source, Content, MediaThumbnail, MediaContent, ItunesFeedMeta, ItunesEntryMeta, GeoLocation) now implement the full dict protocol: `get()`, `keys()`, `values()`, `items()`, `dict()`, `in` operator, and `__getitem__` (#264, #222)
 - Python: geo location field renamed from `where_` to `where` to match Python feedparser API (`entry.where`, `feed.where`) (#249)
+- Core: Atom `entry.guidislink` is now `Some(true)` when `entry.link` is promoted from `entry.id` (no explicit `<link>`), and `Some(false)` when an explicit `<link>` is present; previously always hardcoded to `Some(false)` (#285)
+- Core: `dc:creator` in Atom entries is now used as fallback for `entry.author` when no `<author>` element is present, matching RSS behavior and Python feedparser (#278)
+- Core: RSS 0.92 and 0.90 feeds now report `"rss092"` and `"rss090"` instead of `"rss20"`; RSS 0.91 with Netscape DOCTYPE reports `"rss091n"`, without DOCTYPE reports `"rss091u"`, matching Python feedparser behavior (#283)
 
 ## [0.5.0] - 2026-03-24
 

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -296,6 +296,12 @@ fn parse_feed_element(
                                 if entry.summary.is_none() {
                                     entry.summary = entry.content.first().map(|c| c.value.clone());
                                 }
+                                // #278: dc:creator fallback for author
+                                if entry.author.is_none()
+                                    && let Some(dc) = &entry.dc_creator
+                                {
+                                    entry.author = Some(dc.clone());
+                                }
                                 // #273: promote entry.id → entry.link when no explicit link
                                 promote_entry_id_to_link(&mut entry);
                                 // #275: fallback entry.updated from entry.published
@@ -843,21 +849,21 @@ fn parse_entry(
         buf.clear();
     }
 
-    // Atom uses <id> not <guid>; guidislink is always false when <id> is present.
-    // Python feedparser never sets guidislink=true for Atom entries.
-    entry.guidislink = entry.id.as_ref().map(|_| false);
-
     Ok(entry)
 }
 
 /// Promote entry.id → entry.link when no explicit `<link>` is present (#273).
 ///
-/// `guidislink` is always `Some(false)` for Atom entries (set before this call).
+/// Sets `guidislink = Some(true)` when link is promoted from id, `Some(false)` when
+/// an explicit `<link>` was present. `guidislink` remains `None` when no `<id>` exists.
 fn promote_entry_id_to_link(entry: &mut Entry) {
-    if entry.link.is_none()
-        && let Some(id) = entry.id.as_deref()
-    {
-        entry.link = Some(id.to_string());
+    if let Some(id) = entry.id.as_deref() {
+        if entry.link.is_none() {
+            entry.link = Some(id.to_string());
+            entry.guidislink = Some(true);
+        } else {
+            entry.guidislink = Some(false);
+        }
     }
 }
 
@@ -2672,8 +2678,8 @@ mod tests {
     }
 
     #[test]
-    fn test_atom_entry_guidislink_is_false_when_id_present() {
-        // Atom entries with <id> must have guidislink=Some(false)
+    fn test_atom_entry_guidislink_true_when_id_promoted_to_link() {
+        // #285: when id is promoted to link, guidislink must be Some(true)
         let xml = br#"<?xml version="1.0"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
             <title>Test</title>
@@ -2685,7 +2691,30 @@ mod tests {
         </feed>"#;
 
         let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.entries[0].guidislink, Some(true));
+        assert_eq!(feed.entries[0].link.as_deref(), Some("urn:uuid:1234"));
+    }
+
+    #[test]
+    fn test_atom_entry_guidislink_false_when_explicit_link_present() {
+        // #285: when explicit <link> is present, guidislink must be Some(false)
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <entry>
+                <title>Entry</title>
+                <id>urn:uuid:1234</id>
+                <link href="https://example.com/entry"/>
+                <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
         assert_eq!(feed.entries[0].guidislink, Some(false));
+        assert_eq!(
+            feed.entries[0].link.as_deref(),
+            Some("https://example.com/entry")
+        );
     }
 
     #[test]
@@ -2702,5 +2731,44 @@ mod tests {
 
         let feed = parse_atom10(xml).unwrap();
         assert_eq!(feed.entries[0].guidislink, None);
+    }
+
+    #[test]
+    fn test_atom_entry_dc_creator_fallback_author() {
+        // #278: dc:creator must be used as fallback for entry.author
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <title>Test</title>
+            <entry>
+                <title>Entry</title>
+                <id>urn:uuid:1234</id>
+                <updated>2024-01-01T00:00:00Z</updated>
+                <dc:creator>Jane Doe</dc:creator>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.entries[0].author.as_deref(), Some("Jane Doe"));
+    }
+
+    #[test]
+    fn test_atom_entry_author_takes_precedence_over_dc_creator() {
+        // #278: explicit <author> must take precedence over dc:creator
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <title>Test</title>
+            <entry>
+                <title>Entry</title>
+                <id>urn:uuid:1234</id>
+                <updated>2024-01-01T00:00:00Z</updated>
+                <author><name>John Smith</name></author>
+                <dc:creator>Jane Doe</dc:creator>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.entries[0].author.as_deref(), Some("John Smith"));
     }
 }

--- a/crates/feedparser-rs-core/src/parser/detect.rs
+++ b/crates/feedparser-rs-core/src/parser/detect.rs
@@ -87,8 +87,22 @@ fn detect_json_version_from_partial(data: &[u8]) -> FeedVersion {
     }
 }
 
+/// Returns true if the data contains the Netscape RSS 0.91 DOCTYPE declaration.
+///
+/// Python feedparser uses this to distinguish `rss091n` (Netscape) from `rss091u` (Userland).
+fn has_netscape_rss091_doctype(data: &[u8]) -> bool {
+    // Only scan the first 512 bytes — DOCTYPE always appears before the root element
+    let probe = &data[..data.len().min(512)];
+    // The canonical Netscape DOCTYPE system identifier
+    probe
+        .windows(b"Netscape Communications".len())
+        .any(|w| w == b"Netscape Communications")
+}
+
 /// Detect XML-based feed format (RSS or Atom)
 fn detect_xml_format(data: &[u8]) -> FeedVersion {
+    let has_netscape_doctype = has_netscape_rss091_doctype(data);
+
     let mut reader = Reader::from_reader(data);
     reader.config_mut().trim_text(true);
 
@@ -107,7 +121,13 @@ fn detect_xml_format(data: &[u8]) -> FeedVersion {
                             if attr.key.as_ref() == b"version" {
                                 return match attr.value.as_ref() {
                                     b"0.90" => FeedVersion::Rss090,
-                                    b"0.91" => FeedVersion::Rss091,
+                                    b"0.91" => {
+                                        if has_netscape_doctype {
+                                            FeedVersion::Rss091Netscape
+                                        } else {
+                                            FeedVersion::Rss091Userland
+                                        }
+                                    }
                                     b"0.92" => FeedVersion::Rss092,
                                     b"2.0" => FeedVersion::Rss20,
                                     _ => FeedVersion::Unknown,
@@ -172,9 +192,18 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_rss091() {
+    fn test_detect_rss091_userland() {
         let xml = br#"<rss version="0.91"></rss>"#;
-        assert_eq!(detect_format(xml), FeedVersion::Rss091);
+        assert_eq!(detect_format(xml), FeedVersion::Rss091Userland);
+    }
+
+    #[test]
+    fn test_detect_rss091_netscape() {
+        let xml = br#"<?xml version="1.0"?>
+<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN"
+    "http://my.netscape.com/publish/formats/rss-0.91.dtd">
+<rss version="0.91"></rss>"#;
+        assert_eq!(detect_format(xml), FeedVersion::Rss091Netscape);
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/parser/mod.rs
+++ b/crates/feedparser-rs-core/src/parser/mod.rs
@@ -80,9 +80,15 @@ pub fn parse_with_limits(data: &[u8], limits: crate::ParserLimits) -> Result<Par
 
     // Parse based on detected format, then update the encoding field
     let mut feed = match version {
-        // RSS variants (all use RSS 2.0 parser for now)
-        FeedVersion::Rss20 | FeedVersion::Rss092 | FeedVersion::Rss091 | FeedVersion::Rss090 => {
-            rss::parse_rss20_with_limits(utf8_bytes, limits)
+        // RSS variants (all use RSS 2.0 parser; overwrite version after parsing)
+        FeedVersion::Rss20
+        | FeedVersion::Rss092
+        | FeedVersion::Rss091Netscape
+        | FeedVersion::Rss091Userland
+        | FeedVersion::Rss090 => {
+            let mut parsed = rss::parse_rss20_with_limits(utf8_bytes, limits)?;
+            parsed.version = version;
+            Ok(parsed)
         }
 
         // Atom variants
@@ -124,5 +130,51 @@ mod tests {
         assert!(feed.bozo, "unrecognized input must set bozo");
         assert_eq!(feed.version, crate::types::FeedVersion::Unknown);
         assert!(feed.entries.is_empty());
+    }
+
+    #[test]
+    fn test_rss091n_version_string() {
+        // #283: RSS 0.91 with Netscape DOCTYPE must report "rss091n"
+        let xml = br#"<?xml version="1.0"?>
+<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN"
+    "http://my.netscape.com/publish/formats/rss-0.91.dtd">
+<rss version="0.91">
+<channel><title>T</title><link>http://example.com</link><description>D</description>
+<language>en</language></channel></rss>"#;
+        let feed = parse(xml).unwrap();
+        assert_eq!(feed.version.as_str(), "rss091n");
+    }
+
+    #[test]
+    fn test_rss091u_version_string() {
+        // #283: RSS 0.91 without Netscape DOCTYPE must report "rss091u"
+        let xml = br#"<?xml version="1.0"?>
+<rss version="0.91">
+<channel><title>T</title><link>http://example.com</link><description>D</description>
+<language>en</language></channel></rss>"#;
+        let feed = parse(xml).unwrap();
+        assert_eq!(feed.version.as_str(), "rss091u");
+    }
+
+    #[test]
+    fn test_rss092_version_string() {
+        // #283: RSS 0.92 feeds must report version "rss092", not "rss20"
+        let xml = br#"<?xml version="1.0"?>
+<rss version="0.92">
+<channel><title>T</title><link>http://example.com</link><description>D</description>
+</channel></rss>"#;
+        let feed = parse(xml).unwrap();
+        assert_eq!(feed.version.as_str(), "rss092");
+    }
+
+    #[test]
+    fn test_rss20_version_string_unchanged() {
+        // #283: RSS 2.0 feeds must still report version "rss20"
+        let xml = br#"<?xml version="1.0"?>
+<rss version="2.0">
+<channel><title>T</title><link>http://example.com</link><description>D</description>
+</channel></rss>"#;
+        let feed = parse(xml).unwrap();
+        assert_eq!(feed.version.as_str(), "rss20");
     }
 }

--- a/crates/feedparser-rs-core/src/types/version.rs
+++ b/crates/feedparser-rs-core/src/types/version.rs
@@ -5,8 +5,10 @@ use std::fmt;
 pub enum FeedVersion {
     /// RSS 0.90
     Rss090,
-    /// RSS 0.91
-    Rss091,
+    /// RSS 0.91 Netscape (with Netscape DOCTYPE)
+    Rss091Netscape,
+    /// RSS 0.91 Userland (without Netscape DOCTYPE)
+    Rss091Userland,
     /// RSS 0.92
     Rss092,
     /// RSS 1.0 (RDF)
@@ -41,7 +43,8 @@ impl FeedVersion {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Rss090 => "rss090",
-            Self::Rss091 => "rss091",
+            Self::Rss091Netscape => "rss091n",
+            Self::Rss091Userland => "rss091u",
             Self::Rss092 => "rss092",
             Self::Rss10 => "rss10",
             Self::Rss20 => "rss20",

--- a/crates/feedparser-rs-core/tests/integration_tests.rs
+++ b/crates/feedparser-rs-core/tests/integration_tests.rs
@@ -859,8 +859,8 @@ fn test_atom_entry_id_promoted_to_link_when_no_explicit_link() {
     );
     assert_eq!(
         entry0.guidislink,
-        Some(false),
-        "guidislink is always false for Atom entries (Python feedparser never sets true for Atom)"
+        Some(true),
+        "guidislink is true when entry.link is promoted from entry.id (#285)"
     );
 }
 


### PR DESCRIPTION
## Summary

- **#285**: `entry.guidislink` now correctly set to `true` when `entry.link` is promoted from `<id>` (no explicit `<link>` element), `false` when explicit `<link>` present
- **#278**: `dc:creator` in Atom entries now mapped to `entry.author`, matching Python feedparser behavior (was working for RSS but not Atom)
- **#283**: RSS 0.91 Netscape (`rss091n`), RSS 0.91 Userland (`rss091u`), and RSS 0.92 (`rss092`) version strings now correctly detected via DOCTYPE sniffing and version attribute parsing

## Test plan

- [ ] Atom feed with `<id>` only (no `<link>`) → `entry.guidislink == True`, `entry.link` set
- [ ] Atom feed with explicit `<link>` → `entry.guidislink == False`
- [ ] Atom feed with `<dc:creator>` → `entry.author` set
- [ ] Atom feed with `<dc:creator>` AND `<author>` → `entry.author` uses `<author>` (dc:creator is fallback)
- [ ] RSS 0.91 with Netscape DOCTYPE → `feed.version == 'rss091n'`
- [ ] RSS 0.91 without DOCTYPE → `feed.version == 'rss091u'`
- [ ] RSS 0.92 → `feed.version == 'rss092'`
- [ ] Valid feeds do NOT produce `bozo = true`

Closes #285
Closes #278
Closes #283