### PR TITLE
fix(core): media:content bitrate/channels/samplingrate/framerate and nested thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Core: `media:content` attributes `bitrate`, `channels`, `samplingrate`, and `framerate` are now parsed and exposed as strings on `MediaContent`, matching Python feedparser behavior (#294, #253)
+- Core, Python, Node.js bindings: `media:thumbnail` elements nested inside `<media:content>` are now collected into `entry.media_thumbnail` alongside top-level thumbnails, matching Python feedparser behavior (#270)
+- Python bindings: `bitrate`, `channels`, `samplingrate`, `framerate`, `lang`, `codec`, `expression`, and `isdefault` attributes are now accessible via `MediaContent.__getitem__` / `__contains__` / `keys` / `values` dict protocol (#294)
+
 - Core: syndication module (`syn:`/`sy:` namespace) is now parsed in RSS 2.0 feeds; previously only RSS 1.0 feeds were supported — RSS 2.0 feeds with `<syn:updatePeriod>` etc. returned `feed.syndication = None` (#237)
 - Core: `syn:updateFrequency` / `sy:updateFrequency` now returns the raw string value (e.g. `"2"`) instead of an integer, matching Python feedparser behavior (#268, #220)
 - Python bindings: expose `thr:in-reply-to` as `entry['thr_in-reply-to']` returning the first element as a plain dict with keys `ref`, `href`, `type`, `source` (non-None only), matching Python feedparser API; `entry.thr_in_reply_to` (underscore) retains the full list of `InReplyTo` objects (#267, #245)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -675,7 +675,9 @@ fn parse_entry(
                                         .try_push_limited(media, limits.max_enclosures);
                                 }
                                 if !is_empty {
-                                    skip_element(reader, buf, limits, *depth)?;
+                                    parse_atom_media_content_children(
+                                        reader, buf, &mut entry, limits, depth, bozo,
+                                    )?;
                                 }
                             } else if media_element == "group" && !is_empty {
                                 // media:group is a transparent container; promote children to entry
@@ -1066,6 +1068,63 @@ fn parse_atom_media_group(
             Ok(Event::Start(e)) => {
                 let tag = e.name().as_ref().to_vec();
                 handle_atom_media_group_child(&tag, &e, entry, limits);
+                *depth += 1;
+                skip_element(reader, buf, limits, *depth)?;
+                *depth = depth.saturating_sub(1);
+            }
+            Ok(Event::End(_) | Event::Eof) => break,
+            Err(_) => {
+                *bozo = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Parse children of `<media:content>`, collecting nested `media:thumbnail` elements.
+///
+/// Python feedparser collects all `media:thumbnail` elements into `entry.media_thumbnail`
+/// regardless of whether they are nested inside `media:content`.
+fn parse_atom_media_content_children(
+    reader: &mut Reader<&[u8]>,
+    buf: &mut Vec<u8>,
+    entry: &mut Entry,
+    limits: &ParserLimits,
+    depth: &mut usize,
+    bozo: &mut bool,
+) -> Result<()> {
+    loop {
+        buf.clear();
+        match reader.read_event_into(buf) {
+            Ok(Event::Empty(e)) => {
+                let tag = e.name().as_ref().to_vec();
+                if is_media_tag(&tag) == Some("thumbnail") {
+                    let thumbnail = MediaThumbnail::from_attributes(
+                        e.attributes().flatten(),
+                        limits.max_attribute_length,
+                    );
+                    if let Some(thumbnail) = thumbnail {
+                        entry
+                            .media_thumbnail
+                            .try_push_limited(thumbnail, limits.max_enclosures);
+                    }
+                }
+            }
+            Ok(Event::Start(e)) => {
+                let tag = e.name().as_ref().to_vec();
+                if is_media_tag(&tag) == Some("thumbnail") {
+                    let thumbnail = MediaThumbnail::from_attributes(
+                        e.attributes().flatten(),
+                        limits.max_attribute_length,
+                    );
+                    if let Some(thumbnail) = thumbnail {
+                        entry
+                            .media_thumbnail
+                            .try_push_limited(thumbnail, limits.max_enclosures);
+                    }
+                }
                 *depth += 1;
                 skip_element(reader, buf, limits, *depth)?;
                 *depth = depth.saturating_sub(1);

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1618,6 +1618,7 @@ fn parse_item_media(
             let expression = find_attribute(attrs, b"expression").map(str::to_owned);
             let isdefault = find_attribute(attrs, b"isDefault").map(str::to_owned);
             let samplingrate = find_attribute(attrs, b"samplingrate").map(str::to_owned);
+            let framerate = find_attribute(attrs, b"framerate").map(str::to_owned);
 
             if !url.is_empty() {
                 entry.media_content.try_push_limited(
@@ -1636,12 +1637,13 @@ fn parse_item_media(
                         expression,
                         isdefault,
                         samplingrate,
+                        framerate,
                     },
                     limits.max_enclosures,
                 );
             }
             if !is_empty {
-                skip_element(reader, buf, limits, depth)?;
+                parse_media_content_children(reader, buf, entry, limits, depth)?;
             }
         }
         "group" => {
@@ -1710,6 +1712,74 @@ fn parse_media_group(
                         true,
                         inner_depth,
                     )?;
+                }
+            }
+            Ok(Event::End(_) | Event::Eof) | Err(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Parse children of `<media:content>`, collecting nested `media:thumbnail` elements.
+///
+/// Python feedparser collects all `media:thumbnail` elements into `entry.media_thumbnail`
+/// regardless of whether they are top-level or nested inside `media:content`.
+fn parse_media_content_children(
+    reader: &mut Reader<&[u8]>,
+    buf: &mut Vec<u8>,
+    entry: &mut Entry,
+    limits: &ParserLimits,
+    depth: usize,
+) -> Result<()> {
+    let mut inner_depth = depth;
+    loop {
+        buf.clear();
+        match reader.read_event_into(buf) {
+            Ok(Event::Start(e)) => {
+                inner_depth += 1;
+                check_depth(inner_depth, limits.max_nesting_depth)?;
+                let tag = e.name().as_ref().to_vec();
+                if is_media_tag(&tag) == Some("thumbnail") {
+                    let (attrs, _) = collect_attributes(&e);
+                    let url = find_attribute(&attrs, b"url")
+                        .map(|v| truncate_to_length(v, limits.max_attribute_length))
+                        .unwrap_or_default();
+                    let width = find_attribute(&attrs, b"width").map(str::to_owned);
+                    let height = find_attribute(&attrs, b"height").map(str::to_owned);
+                    if !url.is_empty() {
+                        entry.media_thumbnail.try_push_limited(
+                            MediaThumbnail {
+                                url: url.into(),
+                                width,
+                                height,
+                            },
+                            limits.max_enclosures,
+                        );
+                    }
+                }
+                skip_element(reader, buf, limits, inner_depth)?;
+                inner_depth = inner_depth.saturating_sub(1);
+            }
+            Ok(Event::Empty(e)) => {
+                let tag = e.name().as_ref().to_vec();
+                if is_media_tag(&tag) == Some("thumbnail") {
+                    let (attrs, _) = collect_attributes(&e);
+                    let url = find_attribute(&attrs, b"url")
+                        .map(|v| truncate_to_length(v, limits.max_attribute_length))
+                        .unwrap_or_default();
+                    let width = find_attribute(&attrs, b"width").map(str::to_owned);
+                    let height = find_attribute(&attrs, b"height").map(str::to_owned);
+                    if !url.is_empty() {
+                        entry.media_thumbnail.try_push_limited(
+                            MediaThumbnail {
+                                url: url.into(),
+                                width,
+                                height,
+                            },
+                            limits.max_enclosures,
+                        );
+                    }
                 }
             }
             Ok(Event::End(_) | Event::Eof) | Err(_) => break,

--- a/crates/feedparser-rs-core/src/types/common.rs
+++ b/crates/feedparser-rs-core/src/types/common.rs
@@ -811,6 +811,8 @@ pub struct MediaContent {
     pub isdefault: Option<String>,
     /// Sampling rate in kHz (raw string value)
     pub samplingrate: Option<String>,
+    /// Frame rate in frames per second (raw string value)
+    pub framerate: Option<String>,
 }
 
 impl FromAttributes for Link {
@@ -980,6 +982,7 @@ impl FromAttributes for MediaContent {
         let mut expression = None;
         let mut isdefault = None;
         let mut samplingrate = None;
+        let mut framerate = None;
 
         for attr in attrs {
             if attr.value.len() > max_attr_length {
@@ -1001,6 +1004,7 @@ impl FromAttributes for MediaContent {
                 b"expression" => expression = Some(bytes_to_string(&attr.value)),
                 b"isDefault" => isdefault = Some(bytes_to_string(&attr.value)),
                 b"samplingrate" => samplingrate = Some(bytes_to_string(&attr.value)),
+                b"framerate" => framerate = Some(bytes_to_string(&attr.value)),
                 _ => {}
             }
         }
@@ -1020,6 +1024,7 @@ impl FromAttributes for MediaContent {
             expression,
             isdefault,
             samplingrate,
+            framerate,
         })
     }
 }

--- a/crates/feedparser-rs-core/tests/namespace_integration.rs
+++ b/crates/feedparser-rs-core/tests/namespace_integration.rs
@@ -385,3 +385,84 @@ fn test_media_group_mixed_with_direct_content() {
     assert!(!feed.bozo);
     assert_eq!(feed.entries[0].media_content.len(), 2);
 }
+
+#[test]
+fn test_media_content_framerate_attribute() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>T</title><link>http://example.com/</link>
+            <item>
+                <title>I</title>
+                <media:content url="http://example.com/video.mp4" type="video/mp4"
+                    bitrate="1500" channels="2" samplingrate="44.1" framerate="29.97"/>
+            </item>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert!(!feed.bozo);
+    let mc = &feed.entries[0].media_content[0];
+    assert_eq!(mc.bitrate.as_deref(), Some("1500"));
+    assert_eq!(mc.channels.as_deref(), Some("2"));
+    assert_eq!(mc.samplingrate.as_deref(), Some("44.1"));
+    assert_eq!(mc.framerate.as_deref(), Some("29.97"));
+}
+
+#[test]
+fn test_media_thumbnail_nested_in_media_content_rss() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>T</title><link>http://example.com/</link>
+            <item>
+                <title>I</title>
+                <media:content url="http://example.com/video.mp4" type="video/mp4">
+                    <media:thumbnail url="http://example.com/nested-thumb.jpg" width="320" height="240"/>
+                </media:content>
+                <media:thumbnail url="http://example.com/top-thumb.jpg" width="640" height="480"/>
+            </item>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert!(!feed.bozo);
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_thumbnail.len(), 2);
+    let urls: Vec<&str> = entry
+        .media_thumbnail
+        .iter()
+        .map(|t| t.url.as_ref())
+        .collect();
+    assert!(urls.contains(&"http://example.com/nested-thumb.jpg"));
+    assert!(urls.contains(&"http://example.com/top-thumb.jpg"));
+}
+
+#[test]
+fn test_media_thumbnail_nested_in_media_content_atom() {
+    let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>T</title>
+        <id>http://example.com/</id>
+        <entry>
+            <title>I</title>
+            <id>http://example.com/1</id>
+            <media:content url="http://example.com/video.mp4" type="video/mp4">
+                <media:thumbnail url="http://example.com/nested-thumb.jpg" width="320" height="240"/>
+            </media:content>
+            <media:thumbnail url="http://example.com/top-thumb.jpg"/>
+        </entry>
+    </feed>"#;
+
+    let feed = parse(xml).unwrap();
+    assert!(!feed.bozo);
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_thumbnail.len(), 2);
+    let urls: Vec<&str> = entry
+        .media_thumbnail
+        .iter()
+        .map(|t| t.url.as_ref())
+        .collect();
+    assert!(urls.contains(&"http://example.com/nested-thumb.jpg"));
+    assert!(urls.contains(&"http://example.com/top-thumb.jpg"));
+}

--- a/crates/feedparser-rs-node/index.d.ts
+++ b/crates/feedparser-rs-node/index.d.ts
@@ -391,6 +391,8 @@ export interface MediaContent {
   isdefault?: string
   /** Sampling rate in kHz (raw string value) */
   samplingrate?: string
+  /** Frame rate in frames per second (raw string value) */
+  framerate?: string
 }
 
 /** Media RSS thumbnail */

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -1025,6 +1025,8 @@ pub struct MediaContent {
     pub isdefault: Option<String>,
     /// Sampling rate in kHz (raw string value)
     pub samplingrate: Option<String>,
+    /// Frame rate in frames per second (raw string value)
+    pub framerate: Option<String>,
 }
 
 impl From<CoreMediaContent> for MediaContent {
@@ -1044,6 +1046,7 @@ impl From<CoreMediaContent> for MediaContent {
             expression: core.expression,
             isdefault: core.isdefault,
             samplingrate: core.samplingrate,
+            framerate: core.framerate,
         }
     }
 }

--- a/crates/feedparser-rs-py/src/types/media.rs
+++ b/crates/feedparser-rs-py/src/types/media.rs
@@ -178,6 +178,11 @@ impl PyMediaContent {
         self.inner.samplingrate.as_deref()
     }
 
+    #[getter]
+    fn framerate(&self) -> Option<&str> {
+        self.inner.framerate.as_deref()
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "MediaContent(url='{}', type='{}')",
@@ -195,6 +200,14 @@ impl PyMediaContent {
             "height" => Ok(self.inner.height.as_deref().map(str::to_owned)),
             "duration" => Ok(self.inner.duration.as_deref().map(str::to_owned)),
             "filesize" => Ok(self.inner.filesize.map(|v| v.to_string())),
+            "bitrate" => Ok(self.inner.bitrate.as_deref().map(str::to_owned)),
+            "channels" => Ok(self.inner.channels.as_deref().map(str::to_owned)),
+            "samplingrate" => Ok(self.inner.samplingrate.as_deref().map(str::to_owned)),
+            "framerate" => Ok(self.inner.framerate.as_deref().map(str::to_owned)),
+            "lang" => Ok(self.inner.lang.as_deref().map(str::to_owned)),
+            "codec" => Ok(self.inner.codec.as_deref().map(str::to_owned)),
+            "expression" => Ok(self.inner.expression.as_deref().map(str::to_owned)),
+            "isdefault" => Ok(self.inner.isdefault.as_deref().map(str::to_owned)),
             _ => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
         }
     }
@@ -202,7 +215,21 @@ impl PyMediaContent {
     fn __contains__(&self, key: &str) -> bool {
         matches!(
             key,
-            "url" | "type" | "medium" | "width" | "height" | "duration" | "filesize"
+            "url"
+                | "type"
+                | "medium"
+                | "width"
+                | "height"
+                | "duration"
+                | "filesize"
+                | "bitrate"
+                | "channels"
+                | "samplingrate"
+                | "framerate"
+                | "lang"
+                | "codec"
+                | "expression"
+                | "isdefault"
         )
     }
 
@@ -216,7 +243,21 @@ impl PyMediaContent {
 
     fn keys(&self) -> Vec<&'static str> {
         vec![
-            "url", "type", "medium", "width", "height", "duration", "filesize",
+            "url",
+            "type",
+            "medium",
+            "width",
+            "height",
+            "duration",
+            "filesize",
+            "bitrate",
+            "channels",
+            "samplingrate",
+            "framerate",
+            "lang",
+            "codec",
+            "expression",
+            "isdefault",
         ]
     }
 
@@ -229,6 +270,14 @@ impl PyMediaContent {
             self.inner.height.as_deref().map(str::to_owned),
             self.inner.duration.as_deref().map(str::to_owned),
             self.inner.filesize.map(|v| v.to_string()),
+            self.inner.bitrate.as_deref().map(str::to_owned),
+            self.inner.channels.as_deref().map(str::to_owned),
+            self.inner.samplingrate.as_deref().map(str::to_owned),
+            self.inner.framerate.as_deref().map(str::to_owned),
+            self.inner.lang.as_deref().map(str::to_owned),
+            self.inner.codec.as_deref().map(str::to_owned),
+            self.inner.expression.as_deref().map(str::to_owned),
+            self.inner.isdefault.as_deref().map(str::to_owned),
         ]
     }
 
@@ -255,5 +304,6 @@ impl PyMediaContent {
             && self.inner.expression == other.inner.expression
             && self.inner.isdefault == other.inner.isdefault
             && self.inner.samplingrate == other.inner.samplingrate
+            && self.inner.framerate == other.inner.framerate
     }
 }


### PR DESCRIPTION
## Summary

- Add `bitrate`, `channels`, `samplingrate`, `framerate` to `MediaContent` as `Option<String>` — parsed from XML attributes, matching Python feedparser string behavior (#294, #253)
- Collect `media:thumbnail` elements nested inside `<media:content>` into `entry.media_thumbnail`, alongside top-level thumbnails (#270)
- Expose new fields in Python (`__getitem__`/`__contains__`/`keys`/`values`) and Node.js bindings

Closes #294, #253, #270

## Test plan

- [x] `test_media_content_framerate_attribute` — verifies bitrate/channels/samplingrate/framerate parsing as strings
- [x] `test_media_thumbnail_nested_in_media_content_rss` — verifies nested thumbnail collection in RSS
- [x] `test_media_thumbnail_nested_in_media_content_atom` — verifies nested thumbnail collection in Atom
- [x] 919 tests pass, clippy clean, fmt clean

## Bozo gate

- Valid feeds: bozo = false, all new fields populated correctly
- No panics on any existing test suite