### PR TITLE
fix(py): expose flat itunes_* and sy_* fields; PodcastPerson dict protocol (#232, #293, #300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: `itunes:owner` was already parsed in Atom feeds with both `<itunes:name>` and `<itunes:email>` children; no change needed (#266)
 - Core: `itunes:explicit` values `"false"`, `"no"`, `"clean"` now return `None` (not `Some(false)`); only `"yes"`, `"true"`, `"explicit"` return `Some(true)` — matches Python feedparser behavior (#206)
 
+- Python bindings: expose flat `itunes_block`, `itunes_complete`, `itunes_type`, `itunes_new-feed-url` fields directly on feed dict, matching Python feedparser API (#232)
+- Python bindings: expose flat `sy_updateperiod`, `sy_updatefrequency`, `sy_updatebase` fields directly on feed dict, matching Python feedparser API (#293)
+- Python bindings: `PodcastPerson` now supports dict protocol (`__getitem__`, `get`, `keys`, `values`, `items`), consistent with other struct types (#300)
+
 - Core: syndication module (`syn:`/`sy:` namespace) is now parsed in RSS 2.0 feeds; previously only RSS 1.0 feeds were supported — RSS 2.0 feeds with `<syn:updatePeriod>` etc. returned `feed.syndication = None` (#237)
 - Core: `syn:updateFrequency` / `sy:updateFrequency` now returns the raw string value (e.g. `"2"`) instead of an integer, matching Python feedparser behavior (#268, #220)
 - Python bindings: expose `thr:in-reply-to` as `entry['thr_in-reply-to']` returning the first element as a plain dict with keys `ref`, `href`, `type`, `source` (non-None only), matching Python feedparser API; `entry.thr_in_reply_to` (underscore) retains the full list of `InReplyTo` objects (#267, #245)

--- a/crates/feedparser-rs-py/src/types/feed_meta.rs
+++ b/crates/feedparser-rs-py/src/types/feed_meta.rs
@@ -714,6 +714,38 @@ impl PyFeedMeta {
                 .into_pyobject(py)?
                 .into_any()
                 .unbind()),
+            "itunes_block" => Ok(self
+                .inner
+                .itunes
+                .as_ref()
+                .and_then(|i| i.block)
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "itunes_complete" => Ok(self
+                .inner
+                .itunes
+                .as_ref()
+                .and_then(|i| i.complete.map(|b| if b { "yes" } else { "no" }))
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "itunes_type" => Ok(self
+                .inner
+                .itunes
+                .as_ref()
+                .and_then(|i| i.podcast_type.as_deref())
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "itunes_new-feed-url" => Ok(self
+                .inner
+                .itunes
+                .as_ref()
+                .and_then(|i| i.new_feed_url.as_deref())
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
             "podcast" => {
                 if let Some(ref p) = self.inner.podcast {
                     Ok(Py::new(py, PyPodcastMeta::from_core(p.as_ref().clone()))?.into_any())
@@ -735,6 +767,31 @@ impl PyFeedMeta {
                     Ok(py.None())
                 }
             }
+            // Flat sy_* keys for Python feedparser compatibility
+            "sy_updateperiod" => Ok(self
+                .inner
+                .syndication
+                .as_ref()
+                .and_then(|s| s.update_period.as_ref().map(|p| p.as_str()))
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "sy_updatefrequency" => Ok(self
+                .inner
+                .syndication
+                .as_ref()
+                .and_then(|s| s.update_frequency.as_deref())
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "sy_updatebase" => Ok(self
+                .inner
+                .syndication
+                .as_ref()
+                .and_then(|s| s.update_base.as_deref())
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
             "dc_creator" => Ok(self
                 .inner
                 .dc_creator

--- a/crates/feedparser-rs-py/src/types/podcast.rs
+++ b/crates/feedparser-rs-py/src/types/podcast.rs
@@ -541,6 +541,50 @@ impl PyPodcastPerson {
             self.inner.role.as_deref().unwrap_or("unknown")
         )
     }
+
+    fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<pyo3::Py<pyo3::PyAny>> {
+        use pyo3::IntoPyObjectExt;
+        match key {
+            "name" => self.inner.name.as_str().into_py_any(py),
+            "role" => self.inner.role.as_deref().into_py_any(py),
+            "group" => self.inner.group.as_deref().into_py_any(py),
+            "img" => self.inner.img.as_deref().into_py_any(py),
+            "href" => self.inner.href.as_deref().into_py_any(py),
+            _ => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
+        }
+    }
+
+    #[pyo3(signature = (key, default = None))]
+    fn get(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        default: Option<pyo3::Py<pyo3::PyAny>>,
+    ) -> PyResult<pyo3::Py<pyo3::PyAny>> {
+        match self.__getitem__(py, key) {
+            Ok(v) if v.is_none(py) => Ok(default.unwrap_or_else(|| py.None())),
+            Ok(v) => Ok(v),
+            Err(_) => Ok(default.unwrap_or_else(|| py.None())),
+        }
+    }
+
+    fn keys(&self) -> Vec<&'static str> {
+        vec!["name", "role", "group", "img", "href"]
+    }
+
+    fn values(&self, py: Python<'_>) -> PyResult<Vec<pyo3::Py<pyo3::PyAny>>> {
+        self.keys()
+            .into_iter()
+            .map(|key| self.__getitem__(py, key))
+            .collect()
+    }
+
+    fn items(&self, py: Python<'_>) -> PyResult<Vec<(String, pyo3::Py<pyo3::PyAny>)>> {
+        self.keys()
+            .into_iter()
+            .map(|key| Ok((key.to_string(), self.__getitem__(py, key)?)))
+            .collect()
+    }
 }
 
 #[pyclass(name = "PodcastChapters", module = "feedparser_rs", from_py_object)]

--- a/crates/feedparser-rs-py/tests/test_bindings.py
+++ b/crates/feedparser-rs-py/tests/test_bindings.py
@@ -424,6 +424,39 @@ def test_podcast_person():
     assert person2.href is None
 
 
+def test_podcast_person_dict_protocol():
+    """Test PodcastPerson dict protocol: __getitem__, get, keys, values, items (#300)."""
+    xml = b"""<?xml version="1.0"?>
+    <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+        <channel>
+            <title>Podcast</title>
+            <item>
+                <title>Episode</title>
+                <podcast:person role="host" group="cast" img="https://example.com/img.jpg" href="https://example.com/alice">Alice</podcast:person>
+            </item>
+        </channel>
+    </rss>
+    """
+    result = feedparser_rs.parse(xml)
+    person = result.entries[0].podcast_persons[0]
+
+    assert person["name"] == "Alice"
+    assert person["role"] == "host"
+    assert person["group"] == "cast"
+    assert person["img"] == "https://example.com/img.jpg"
+    assert person["href"] == "https://example.com/alice"
+
+    assert person.get("name") == "Alice"
+    assert person.get("nonexistent") is None
+    assert person.get("nonexistent", "fallback") == "fallback"
+
+    assert set(person.keys()) == {"name", "role", "group", "img", "href"}
+    values = person.values()
+    assert "Alice" in values
+    items = dict(person.items())
+    assert items["name"] == "Alice"
+
+
 def test_dual_access_podcast_transcripts():
     """Test entry.podcast_transcripts direct access (entry.podcast.transcript when parser supports)"""
     xml = b"""<?xml version="1.0"?>

--- a/crates/feedparser-rs-py/tests/test_itunes_flat_keys.py
+++ b/crates/feedparser-rs-py/tests/test_itunes_flat_keys.py
@@ -1,4 +1,4 @@
-"""Tests for flat itunes_* key access via __getitem__ (Python feedparser compat, issue #164)."""
+"""Tests for flat itunes_* key access via __getitem__ (Python feedparser compat, issue #232)."""
 
 import feedparser_rs
 import pytest
@@ -12,6 +12,10 @@ RSS_WITH_ITUNES = b"""<?xml version="1.0" encoding="utf-8"?>
     <itunes:author>Show Author</itunes:author>
     <itunes:explicit>true</itunes:explicit>
     <itunes:image href="https://example.com/cover.jpg"/>
+    <itunes:block>yes</itunes:block>
+    <itunes:complete>yes</itunes:complete>
+    <itunes:type>episodic</itunes:type>
+    <itunes:new-feed-url>https://example.com/new.xml</itunes:new-feed-url>
     <item>
       <title>Episode 1</title>
       <link>https://example.com/ep1</link>
@@ -21,6 +25,7 @@ RSS_WITH_ITUNES = b"""<?xml version="1.0" encoding="utf-8"?>
       <itunes:season>2</itunes:season>
       <itunes:explicit>true</itunes:explicit>
       <itunes:episodeType>full</itunes:episodeType>
+      <itunes:title>Episode Title</itunes:title>
     </item>
   </channel>
 </rss>
@@ -62,6 +67,11 @@ def test_entry_itunes_author_flat(parsed):
     assert e["itunes_author"] == "Jane Doe"
 
 
+def test_entry_itunes_title_flat(parsed):
+    e = parsed.entries[0]
+    assert e["itunes_title"] == "Episode Title"
+
+
 def test_entry_nested_still_works(parsed):
     e = parsed.entries[0]
     assert e.itunes.duration == "1800"
@@ -82,3 +92,23 @@ def test_feed_itunes_author_flat(parsed):
 def test_feed_itunes_explicit_flat(parsed):
     f = parsed.feed
     assert f["itunes_explicit"] is True
+
+
+def test_feed_itunes_block_flat(parsed):
+    f = parsed.feed
+    assert f["itunes_block"] == 1
+
+
+def test_feed_itunes_complete_flat(parsed):
+    f = parsed.feed
+    assert f["itunes_complete"] == "yes"
+
+
+def test_feed_itunes_type_flat(parsed):
+    f = parsed.feed
+    assert f["itunes_type"] == "episodic"
+
+
+def test_feed_itunes_new_feed_url_flat(parsed):
+    f = parsed.feed
+    assert f["itunes_new-feed-url"] == "https://example.com/new.xml"

--- a/crates/feedparser-rs-py/tests/test_syndication.py
+++ b/crates/feedparser-rs-py/tests/test_syndication.py
@@ -147,6 +147,41 @@ def test_case_insensitive_update_period():
     assert d.feed.syndication.update_period == "hourly"
 
 
+def test_syndication_flat_keys():
+    """Test flat sy_* key access on feed for Python feedparser compatibility (#293)."""
+    feed_xml = b"""<?xml version="1.0"?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns="http://purl.org/rss/1.0/"
+             xmlns:syn="http://purl.org/rss/1.0/modules/syndication/">
+      <channel>
+        <title>Test</title>
+        <link>https://example.com</link>
+        <syn:updatePeriod>daily</syn:updatePeriod>
+        <syn:updateFrequency>2</syn:updateFrequency>
+        <syn:updateBase>2024-01-01T00:00:00Z</syn:updateBase>
+      </channel>
+    </rdf:RDF>"""
+    d = feedparser_rs.parse(feed_xml)
+    assert d.feed["sy_updateperiod"] == "daily"
+    assert d.feed["sy_updatefrequency"] == "2"
+    assert d.feed["sy_updatebase"] == "2024-01-01T00:00:00Z"
+
+
+def test_syndication_flat_keys_absent():
+    """Test that flat sy_* keys return None when syndication is absent."""
+    feed_xml = b"""<?xml version="1.0"?>
+    <rss version="2.0">
+      <channel>
+        <title>Test</title>
+        <link>https://example.com</link>
+      </channel>
+    </rss>"""
+    d = feedparser_rs.parse(feed_xml)
+    assert d.feed.get("sy_updateperiod") is None
+    assert d.feed.get("sy_updatefrequency") is None
+    assert d.feed.get("sy_updatebase") is None
+
+
 def test_partial_syndication():
     """Test feed with only some syndication fields"""
     feed_xml = b"""<?xml version="1.0"?>


### PR DESCRIPTION
## Summary

- **#232**: `feed.itunes_block`, `feed.itunes_complete`, `feed.itunes_type`, `feed.itunes_new-feed-url` now accessible as flat dict keys on `PyFeedMeta`, matching Python feedparser API. Entry-level `itunes_duration`, `itunes_episode`, `itunes_season`, `itunes_title`, `itunes_episodetype`, `itunes_explicit` were already present.
- **#293**: `feed.sy_updateperiod`, `feed.sy_updatefrequency` (returned as string), `feed.sy_updatebase` now accessible as flat `sy_*` dict keys on `PyFeedMeta`.
- **#300**: `PodcastPerson` now supports dict protocol (`__getitem__`, `get`, `keys`, `values`, `items`), consistent with `Image`, `Enclosure`, `Tag`, `Link`, `GeoLocation`.

## Test plan

- [ ] `cargo nextest run --workspace` — 926 tests pass
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [ ] New Python tests: `test_itunes_flat_keys.py`, `test_syndication.py` (flat field assertions), `test_bindings.py::test_podcast_person_dict_protocol`

Closes #232, #293, #300