### PR TITLE
fix(core): promote webMaster to feed.publisher flat field with raw string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: `media:content` attributes `bitrate`, `channels`, `samplingrate`, and `framerate` are now parsed and exposed as strings on `MediaContent`, matching Python feedparser behavior (#294, #253)
 - Core, Python, Node.js bindings: `media:thumbnail` elements nested inside `<media:content>` are now collected into `entry.media_thumbnail` alongside top-level thumbnails, matching Python feedparser behavior (#270)
 - Python bindings: `bitrate`, `channels`, `samplingrate`, `framerate`, `lang`, `codec`, `expression`, and `isdefault` attributes are now accessible via `MediaContent.__getitem__` / `__contains__` / `keys` / `values` dict protocol (#294)
+- Core: `feed.publisher` flat field is now populated with the raw `<webMaster>` string (e.g. `"webmaster@example.com (Web Master)"`) matching how `feed.author` is populated from `<managingEditor>`; previously `feed.publisher` was `None` (#277, #218)
 - Core: `itunes:owner` in RSS feeds now promotes to `feed.publisher_detail` (name + email) if no publisher is already set; existing publisher from `<webMaster>` is not overridden (#280)
 - Core: `itunes:owner` was already parsed in Atom feeds with both `<itunes:name>` and `<itunes:email>` children; no change needed (#266)
 - Core: `itunes:explicit` values `"false"`, `"no"`, `"clean"` now return `None` (not `Some(false)`); only `"yes"`, `"true"`, `"explicit"` return `Some(true)` — matches Python feedparser behavior (#206)

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -492,6 +492,8 @@ fn parse_channel_standard(
         b"webMaster" => {
             let text = read_text_str(reader, buf, limits)?;
             feed.feed.set_publisher(parse_rss_person(&text));
+            // Preserve raw string in publisher flat field; publisher_detail has parsed fields
+            feed.feed.publisher = Some(text.into());
         }
         b"copyright" => {
             let text = read_text_str(reader, buf, limits)?;
@@ -3657,7 +3659,69 @@ mod tests {
         let pub_detail = feed.feed.publisher_detail.as_ref().unwrap();
         assert_eq!(pub_detail.name.as_deref(), Some("Web Master"));
         assert_eq!(pub_detail.email.as_deref(), Some("webmaster@example.com"));
-        assert_eq!(feed.feed.publisher.as_deref(), Some("Web Master"));
+        assert_eq!(
+            feed.feed.publisher.as_deref(),
+            Some("webmaster@example.com (Web Master)")
+        );
+    }
+
+    #[test]
+    fn test_rss_webmaster_email_only() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <title>T</title>
+                <link>http://x.com</link>
+                <webMaster>webmaster@example.com</webMaster>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo);
+
+        let pub_detail = feed.feed.publisher_detail.as_ref().unwrap();
+        assert_eq!(pub_detail.email.as_deref(), Some("webmaster@example.com"));
+        assert!(pub_detail.name.is_none());
+        assert_eq!(
+            feed.feed.publisher.as_deref(),
+            Some("webmaster@example.com")
+        );
+    }
+
+    #[test]
+    fn test_rss_webmaster_missing() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <title>T</title>
+                <link>http://x.com</link>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo);
+        assert!(feed.feed.publisher.is_none());
+        assert!(feed.feed.publisher_detail.is_none());
+    }
+
+    #[test]
+    fn test_rss_webmaster_malformed_no_email() {
+        // No @ sign — treated as plain name, publisher raw string still set
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0">
+            <channel>
+                <title>T</title>
+                <link>http://x.com</link>
+                <webMaster>not-an-email</webMaster>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo);
+        assert_eq!(feed.feed.publisher.as_deref(), Some("not-an-email"));
+        let pub_detail = feed.feed.publisher_detail.as_ref().unwrap();
+        assert_eq!(pub_detail.name.as_deref(), Some("not-an-email"));
+        assert!(pub_detail.email.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #277: `feed.publisher` was `None` when `<webMaster>` was present — now set to raw string
- Fixes #218: `feed.publisher` returned only the display name (stripped) — now preserves the full raw string (e.g. `'webmaster@example.com (Web Master)'`)

Both fixes mirror the existing `managingEditor` → `feed.author` pattern: store raw string on the flat field, populate `_detail` from parsed components.

## Changes

- `crates/feedparser-rs-core/src/parser/rss.rs`: set `feed.feed.publisher = Some(text.into())` before calling `set_publisher()` in the `webMaster` branch
- Updated `test_rss_webmaster_publisher_detail` to expect raw string
- Added 3 new tests: email-only, missing tag, malformed string without `@`
- `CHANGELOG.md`: added entry under `[Unreleased] ### Fixed`

## Bozo pattern check

- Valid feed with `<webMaster>` → `bozo = false`, `feed.publisher` set correctly
- Missing `<webMaster>` → `bozo = false`, `feed.publisher = None`
- Malformed value (no email) → parsed as plain name, no panic, no bozo

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 929/929 passed
- [x] `cargo deny check` — OK
- [x] `cargo doc --no-deps` — OK
- [x] `cargo build --examples --benches` — OK
- [x] `cargo test --doc` — OK