### PR TITLE
fix(core): itunes:complete as raw string, subtitle/summary promotion, duration type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `ItunesFeedMeta.complete` changed from `Option<bool>` to `Option<String>` to return the raw XML text value (e.g. `"Yes"`, `"No"`) instead of a parsed boolean (#281)
+- `itunes:subtitle` now always overrides `<description>` for `feed.subtitle` regardless of XML element order; previously it only set subtitle when absent (#257)
+- `itunes:summary` populates new `feed.summary` field instead of aliasing to `feed.subtitle` (#257)
+- Entry-level `itunes:subtitle` and `itunes:summary` promotion is now order-independent via post-processing (#257)
+- Atom entry `itunes:subtitle` now promotes to `entry.subtitle` (was missing) (#257)
+
+### Added
+
+- Core, Python, Node.js bindings: `FeedMeta.summary` and `FeedMeta.summary_detail` fields populated from `itunes:summary` (#257)
+- Python binding: `feed.summary` and `feed["summary"]` now return the `itunes:summary` value (#257)
+
 ### Fixed
 
 - Core: `media:content` attributes `bitrate`, `channels`, `samplingrate`, and `framerate` are now parsed and exposed as strings on `MediaContent`, matching Python feedparser behavior (#294, #253)
@@ -16,11 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: `itunes:owner` in RSS feeds now promotes to `feed.publisher_detail` (name + email) if no publisher is already set; existing publisher from `<webMaster>` is not overridden (#280)
 - Core: `itunes:owner` was already parsed in Atom feeds with both `<itunes:name>` and `<itunes:email>` children; no change needed (#266)
 - Core: `itunes:explicit` values `"false"`, `"no"`, `"clean"` now return `None` (not `Some(false)`); only `"yes"`, `"true"`, `"explicit"` return `Some(true)` — matches Python feedparser behavior (#206)
-
-- Python bindings: expose flat `itunes_block`, `itunes_complete`, `itunes_type`, `itunes_new-feed-url` fields directly on feed dict, matching Python feedparser API (#232)
-- Python bindings: expose flat `sy_updateperiod`, `sy_updatefrequency`, `sy_updatebase` fields directly on feed dict, matching Python feedparser API (#293)
-- Python bindings: `PodcastPerson` now supports dict protocol (`__getitem__`, `get`, `keys`, `values`, `items`), consistent with other struct types (#300)
-
+- `itunes:duration` confirmed as string type in core and all bindings (regression test added) (#265)
 - Core: syndication module (`syn:`/`sy:` namespace) is now parsed in RSS 2.0 feeds; previously only RSS 1.0 feeds were supported — RSS 2.0 feeds with `<syn:updatePeriod>` etc. returned `feed.syndication = None` (#237)
 - Core: `syn:updateFrequency` / `sy:updateFrequency` now returns the raw string value (e.g. `"2"`) instead of an integer, matching Python feedparser behavior (#268, #220)
 - Python bindings: expose `thr:in-reply-to` as `entry['thr_in-reply-to']` returning the first element as a plain dict with keys `ref`, `href`, `type`, `source` (non-None only), matching Python feedparser API; `entry.thr_in_reply_to` (underscore) retains the full list of `InReplyTo` objects (#267, #245)

--- a/crates/feedparser-rs-core/examples/podcast_feed.rs
+++ b/crates/feedparser-rs-core/examples/podcast_feed.rs
@@ -94,7 +94,11 @@ fn display_podcast_metadata(feed: &feedparser_rs::ParsedFeed) {
             println!("  Type: {podcast_type}");
         }
 
-        if itunes.complete == Some(true) {
+        if itunes
+            .complete
+            .as_deref()
+            .is_some_and(|v| v.eq_ignore_ascii_case("yes"))
+        {
             println!("  Status: Complete (no more episodes will be released)");
         }
     }

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -5,9 +5,9 @@ use crate::{
     error::{FeedError, Result},
     namespace::{content, dublin_core, georss, media_rss, slash, threading},
     types::{
-        Content, Enclosure, Entry, FeedVersion, Generator, Image, ItunesCategory, ItunesEntryMeta,
-        ItunesFeedMeta, ItunesOwner, Link, MediaContent, MediaThumbnail, ParsedFeed, Person,
-        Source, Tag, TextConstruct, TextType, parse_explicit,
+        Content, Enclosure, Entry, FeedMeta, FeedVersion, Generator, Image, ItunesCategory,
+        ItunesEntryMeta, ItunesFeedMeta, ItunesOwner, Link, MediaContent, MediaThumbnail,
+        ParsedFeed, Person, Source, Tag, TextConstruct, TextType, parse_explicit,
     },
     util::{base_url::BaseUrlContext, parse_date, text::truncate_to_length},
 };
@@ -105,6 +105,8 @@ pub fn parse_atom10_with_limits(data: &[u8], limits: ParserLimits) -> Result<Par
                     feed.bozo = true;
                     feed.bozo_exception = Some(e.to_string());
                 }
+                // Post-process: iTunes subtitle/summary always win (order-independent)
+                apply_itunes_feed_promotions(&mut feed.feed);
                 // #274: promote feed.id → feed.link when no explicit link was found
                 if feed.feed.link.is_none()
                     && let Some(id) = feed.feed.id.as_deref()
@@ -132,6 +134,51 @@ pub fn parse_atom10_with_limits(data: &[u8], limits: ParserLimits) -> Result<Par
     }
 
     Ok(feed)
+}
+
+/// Apply iTunes subtitle/summary promotions to feed-level fields.
+///
+/// Called after all XML elements have been parsed. Atom uses a single-loop model so
+/// itunes: and standard elements appear in document order — post-processing ensures
+/// promotion is order-independent. Empty/whitespace-only values do not override valid data.
+fn apply_itunes_feed_promotions(feed: &mut FeedMeta) {
+    // Clone to avoid simultaneous immutable + mutable borrow on `feed`.
+    let subtitle = feed.itunes.as_ref().and_then(|it| it.subtitle.clone());
+    let summary = feed.itunes.as_ref().and_then(|it| it.summary.clone());
+
+    if let Some(ref s) = subtitle
+        && !s.trim().is_empty()
+    {
+        feed.set_subtitle(TextConstruct::text(s));
+    }
+    if let Some(ref s) = summary
+        && !s.trim().is_empty()
+    {
+        feed.set_summary(TextConstruct::text(s));
+        if feed.subtitle.is_none() {
+            feed.set_subtitle(TextConstruct::text(s));
+        }
+    }
+}
+
+/// Apply iTunes subtitle/summary promotions to entry-level fields.
+///
+/// Called after all XML elements in an entry have been parsed.
+fn apply_itunes_entry_promotions(entry: &mut Entry) {
+    // Clone to avoid simultaneous immutable + mutable borrow on `entry`.
+    let subtitle = entry.itunes.as_ref().and_then(|it| it.subtitle.clone());
+    let summary = entry.itunes.as_ref().and_then(|it| it.summary.clone());
+
+    if let Some(ref s) = subtitle
+        && !s.trim().is_empty()
+    {
+        entry.set_subtitle(TextConstruct::text(s));
+    }
+    if let Some(ref s) = summary
+        && !s.trim().is_empty()
+    {
+        entry.set_summary(TextConstruct::text(s));
+    }
 }
 
 /// Parse <feed> element
@@ -306,6 +353,8 @@ fn parse_feed_element(
                                 promote_entry_id_to_link(&mut entry);
                                 // #275: fallback entry.updated from entry.published
                                 promote_entry_published_to_updated(&mut entry);
+                                // Post-process: iTunes subtitle/summary promotion (order-independent)
+                                apply_itunes_entry_promotions(&mut entry);
                                 feed.entries.push(entry);
                             }
                             Err(e) => {
@@ -395,9 +444,6 @@ fn parse_feed_element(
                             true
                         } else if is_itunes_tag(tag, b"subtitle") && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
-                            if feed.feed.subtitle.is_none() {
-                                feed.feed.set_subtitle(TextConstruct::text(&text));
-                            }
                             let itunes = feed
                                 .feed
                                 .itunes
@@ -406,9 +452,6 @@ fn parse_feed_element(
                             true
                         } else if is_itunes_tag(tag, b"summary") && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
-                            if feed.feed.subtitle.is_none() {
-                                feed.feed.set_subtitle(TextConstruct::text(&text));
-                            }
                             let itunes = feed
                                 .feed
                                 .itunes
@@ -449,7 +492,7 @@ fn parse_feed_element(
                                 .feed
                                 .itunes
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
-                            itunes.complete = Some(text.trim().eq_ignore_ascii_case("Yes"));
+                            itunes.complete = Some(text.trim().to_string());
                             true
                         } else if is_itunes_tag(tag, b"new-feed-url") && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
@@ -803,9 +846,6 @@ fn parse_entry(
                         } else if is_itunes_tag(tag, b"summary") && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
-                            if entry.summary.is_none() {
-                                entry.set_summary(TextConstruct::text(&text));
-                            }
                             let itunes = entry
                                 .itunes
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
@@ -2614,7 +2654,7 @@ mod tests {
             Some("https://example.com/cover.jpg")
         );
         assert_eq!(itunes.podcast_type.as_deref(), Some("serial"));
-        assert_eq!(itunes.complete, Some(true));
+        assert_eq!(itunes.complete.as_deref(), Some("Yes"));
         assert_eq!(
             itunes.new_feed_url.as_deref(),
             Some("https://example.com/new.xml")
@@ -2869,5 +2909,134 @@ mod tests {
 
         let feed = parse_atom10(xml).unwrap();
         assert_eq!(feed.entries[0].author.as_deref(), Some("John Smith"));
+    }
+
+    // =========================================================================
+    // Regression tests for #257, #281 (Atom-specific)
+    // =========================================================================
+
+    // TC-281-3: Atom itunes:complete 'Yes' returns raw string
+    #[test]
+    fn test_tc_281_3_atom_itunes_complete_raw_string() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>P</title>
+            <itunes:complete>Yes</itunes:complete>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(
+            feed.feed.itunes.as_ref().unwrap().complete.as_deref(),
+            Some("Yes")
+        );
+    }
+
+    // TC-257-9: Atom entry itunes:subtitle promotes to entry.subtitle
+    #[test]
+    fn test_tc_257_9_atom_entry_itunes_subtitle_promotes() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Feed</title>
+            <entry>
+                <title>E</title>
+                <id>urn:test:1</id>
+                <updated>2024-01-01T00:00:00Z</updated>
+                <itunes:subtitle>Atom episode subtitle</itunes:subtitle>
+            </entry>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        let entry = &feed.entries[0];
+        assert_eq!(entry.subtitle.as_deref(), Some("Atom episode subtitle"));
+        assert_eq!(
+            entry.itunes.as_ref().unwrap().subtitle.as_deref(),
+            Some("Atom episode subtitle")
+        );
+    }
+
+    // TC-257-10: Atom feed: itunes:subtitle overrides <subtitle> regardless of order
+    #[test]
+    fn test_tc_257_10_atom_itunes_subtitle_overrides_subtitle() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Feed</title>
+            <subtitle>Atom subtitle</subtitle>
+            <itunes:subtitle>iTunes subtitle</itunes:subtitle>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("iTunes subtitle"),
+            "Post-processing must override standard <subtitle> with itunes:subtitle"
+        );
+    }
+
+    // TC-257-11: Atom feed: itunes:subtitle before <subtitle> — post-processing still wins
+    #[test]
+    fn test_tc_257_11_atom_itunes_subtitle_before_subtitle_post_processing_wins() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Feed</title>
+            <itunes:subtitle>iTunes subtitle</itunes:subtitle>
+            <subtitle>Atom subtitle</subtitle>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("iTunes subtitle"),
+            "Reversed order — post-processing guarantees iTunes wins"
+        );
+    }
+
+    // TC-257: Atom itunes:summary populates feed.summary
+    #[test]
+    fn test_tc_257_atom_itunes_summary_populates_feed_summary() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Feed</title>
+            <subtitle>Atom subtitle</subtitle>
+            <itunes:summary>Podcast summary</itunes:summary>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.feed.summary.as_deref(), Some("Podcast summary"));
+        assert_eq!(feed.feed.subtitle.as_deref(), Some("Atom subtitle"));
+    }
+
+    // TC-257-12A: Atom — empty itunes:subtitle does NOT override valid <subtitle>
+    #[test]
+    fn test_tc_257_12a_atom_empty_itunes_subtitle_no_override() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Feed</title>
+            <subtitle>Valid Atom subtitle</subtitle>
+            <itunes:subtitle></itunes:subtitle>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("Valid Atom subtitle"),
+            "Empty itunes:subtitle must not override valid Atom <subtitle>"
+        );
+    }
+
+    // TC-257-12B: Atom — itunes:subtitle only present (no <subtitle>) sets feed.subtitle
+    #[test]
+    fn test_tc_257_12b_atom_itunes_subtitle_only_no_regression() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Feed</title>
+            <itunes:subtitle>Only iTunes subtitle</itunes:subtitle>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("Only iTunes subtitle"),
+            "itunes:subtitle must set feed.subtitle when no native <subtitle> present"
+        );
     }
 }

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -5,10 +5,10 @@ use crate::{
     error::{FeedError, Result},
     namespace::{content, dublin_core, georss, media_rss, slash, syndication, threading},
     types::{
-        Enclosure, Entry, FeedVersion, Image, ItunesCategory, ItunesEntryMeta, ItunesFeedMeta,
-        ItunesOwner, Link, MediaContent, MediaThumbnail, ParsedFeed, Person, PodcastChapters,
-        PodcastEntryMeta, PodcastFunding, PodcastMeta, PodcastPerson, PodcastSoundbite,
-        PodcastTranscript, Source, Tag, TextConstruct, TextType, parse_explicit,
+        Enclosure, Entry, FeedMeta, FeedVersion, Image, ItunesCategory, ItunesEntryMeta,
+        ItunesFeedMeta, ItunesOwner, Link, MediaContent, MediaThumbnail, ParsedFeed, Person,
+        PodcastChapters, PodcastEntryMeta, PodcastFunding, PodcastMeta, PodcastPerson,
+        PodcastSoundbite, PodcastTranscript, Source, Tag, TextConstruct, TextType, parse_explicit,
     },
     util::{
         base_url::BaseUrlContext,
@@ -160,6 +160,53 @@ pub fn parse_rss20_with_limits(data: &[u8], limits: ParserLimits) -> Result<Pars
     Ok(feed)
 }
 
+/// Apply iTunes subtitle/summary promotions to feed-level fields.
+///
+/// Called after all XML elements in a channel/feed have been parsed, so promotion
+/// is order-independent regardless of where itunes: elements appear in the document.
+/// Empty/whitespace-only iTunes values are filtered and do not override valid data.
+fn apply_itunes_feed_promotions(feed: &mut FeedMeta) {
+    // Clone to avoid simultaneous immutable + mutable borrow on `feed`.
+    let subtitle = feed.itunes.as_ref().and_then(|it| it.subtitle.clone());
+    let summary = feed.itunes.as_ref().and_then(|it| it.summary.clone());
+
+    if let Some(ref s) = subtitle
+        && !s.trim().is_empty()
+    {
+        feed.set_subtitle(TextConstruct::text(s));
+    }
+    if let Some(ref s) = summary
+        && !s.trim().is_empty()
+    {
+        feed.set_summary(TextConstruct::text(s));
+        if feed.subtitle.is_none() {
+            feed.set_subtitle(TextConstruct::text(s));
+        }
+    }
+}
+
+/// Apply iTunes subtitle/summary promotions to entry-level fields.
+///
+/// Called after all XML elements in an item/entry have been parsed. In RSS, entry.subtitle
+/// is iTunes-only (no native RSS <subtitle> for entries), so this always sets a previously-None
+/// field when itunes:subtitle is present. Entry.summary may already be set from <description>.
+fn apply_itunes_entry_promotions(entry: &mut Entry) {
+    // Clone to avoid simultaneous immutable + mutable borrow on `entry`.
+    let subtitle = entry.itunes.as_ref().and_then(|it| it.subtitle.clone());
+    let summary = entry.itunes.as_ref().and_then(|it| it.summary.clone());
+
+    if let Some(ref s) = subtitle
+        && !s.trim().is_empty()
+    {
+        entry.set_subtitle(TextConstruct::text(s));
+    }
+    if let Some(ref s) = summary
+        && !s.trim().is_empty()
+    {
+        entry.set_summary(TextConstruct::text(s));
+    }
+}
+
 /// Parse <channel> element (feed metadata and items)
 fn parse_channel(
     reader: &mut Reader<&[u8]>,
@@ -265,6 +312,9 @@ fn parse_channel(
         buf.clear();
     }
 
+    // Post-process: iTunes subtitle/summary always win over <description> (order-independent)
+    apply_itunes_feed_promotions(&mut feed.feed);
+
     Ok(())
 }
 
@@ -303,6 +353,12 @@ fn parse_channel_item(
             if entry.summary.is_none() {
                 entry.summary = entry.content.first().map(|c| c.value.clone());
             }
+            // Post-process: iTunes subtitle/summary promotion (order-independent).
+            // Note: RSS entry.subtitle is iTunes-only — there is no native RSS <subtitle> for
+            // entries. Unlike feed-level where <description> maps to feed.subtitle, entry
+            // <description> maps to entry.summary, so entry.subtitle is always None before
+            // itunes post-processing.
+            apply_itunes_entry_promotions(&mut entry);
             feed.entries.push(entry);
         }
         Err(e) => {
@@ -563,10 +619,6 @@ fn parse_channel_itunes(
     } else if is_itunes_tag(tag, b"subtitle") {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
-            // Promote to feed.subtitle if not already set
-            if feed.feed.subtitle.is_none() {
-                feed.feed.set_subtitle(TextConstruct::text(&text));
-            }
             let itunes = feed
                 .feed
                 .itunes
@@ -577,11 +629,6 @@ fn parse_channel_itunes(
     } else if is_itunes_tag(tag, b"summary") {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
-            // feed.subtitle doubles as summary in RSS (no separate summary field on FeedMeta)
-            // promote to subtitle only when subtitle is absent
-            if feed.feed.subtitle.is_none() {
-                feed.feed.set_subtitle(TextConstruct::text(&text));
-            }
             let itunes = feed
                 .feed
                 .itunes
@@ -672,7 +719,7 @@ fn parse_channel_itunes(
                 .feed
                 .itunes
                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
-            itunes.complete = Some(text.trim().eq_ignore_ascii_case("Yes"));
+            itunes.complete = Some(text.trim().to_string());
         }
         Ok(true)
     } else if is_itunes_tag(tag, b"new-feed-url") {
@@ -1210,10 +1257,6 @@ fn parse_item_itunes(
     } else if is_itunes_tag(tag, b"subtitle") {
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
-        // Promote to entry.subtitle if not already set
-        if entry.subtitle.is_none() {
-            entry.set_subtitle(TextConstruct::text(&text));
-        }
         let itunes = entry
             .itunes
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
@@ -1222,10 +1265,6 @@ fn parse_item_itunes(
     } else if is_itunes_tag(tag, b"summary") {
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
-        // Promote to entry.summary if not already set
-        if entry.summary.is_none() {
-            entry.set_summary(TextConstruct::text(&text));
-        }
         let itunes = entry
             .itunes
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
@@ -3869,7 +3908,8 @@ mod tests {
     }
 
     #[test]
-    fn test_itunes_subtitle_does_not_overwrite_existing_feed_subtitle() {
+    fn test_itunes_subtitle_overrides_existing_feed_subtitle() {
+        // itunes:subtitle always wins over <description> (post-processing is order-independent)
         let xml = br#"<?xml version="1.0"?>
         <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
             <channel>
@@ -3879,7 +3919,7 @@ mod tests {
             </channel>
         </rss>"#;
         let feed = parse_rss20(xml).unwrap();
-        assert_eq!(feed.feed.subtitle.as_deref(), Some("Existing Subtitle"));
+        assert_eq!(feed.feed.subtitle.as_deref(), Some("iTunes Subtitle"));
         assert_eq!(
             feed.feed.itunes.as_ref().unwrap().subtitle.as_deref(),
             Some("iTunes Subtitle")
@@ -3993,7 +4033,8 @@ mod tests {
     }
 
     #[test]
-    fn test_entry_itunes_summary_does_not_overwrite_existing() {
+    fn test_entry_itunes_summary_overrides_existing() {
+        // itunes:summary always wins over <description> for entry.summary (post-processing)
         let xml = br#"<?xml version="1.0"?>
         <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
             <channel>
@@ -4007,7 +4048,7 @@ mod tests {
         </rss>"#;
         let feed = parse_rss20(xml).unwrap();
         let entry = &feed.entries[0];
-        assert_eq!(entry.summary.as_deref(), Some("Existing Summary"));
+        assert_eq!(entry.summary.as_deref(), Some("iTunes Summary"));
         assert_eq!(
             entry.itunes.as_ref().unwrap().summary.as_deref(),
             Some("iTunes Summary")
@@ -4155,5 +4196,260 @@ mod tests {
         );
         assert_eq!(syn.update_frequency, Some("1".to_string()));
         assert_eq!(syn.update_base.as_deref(), Some("2024-06-01T00:00:00Z"));
+    }
+
+    // =========================================================================
+    // Regression tests for #257, #281, #265
+    // =========================================================================
+
+    // TC-257-1: itunes:subtitle overrides <description> (description BEFORE subtitle)
+    #[test]
+    fn test_tc_257_1_itunes_subtitle_overrides_description_after() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <description>RSS description</description>
+                <itunes:subtitle>iTunes subtitle</itunes:subtitle>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(feed.feed.subtitle.as_deref(), Some("iTunes subtitle"));
+        assert_eq!(
+            feed.feed.itunes.as_ref().unwrap().subtitle.as_deref(),
+            Some("iTunes subtitle")
+        );
+    }
+
+    // TC-257-2: itunes:subtitle overrides even when it appears BEFORE description
+    #[test]
+    fn test_tc_257_2_itunes_subtitle_before_description_post_processing() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <itunes:subtitle>iTunes subtitle</itunes:subtitle>
+                <description>RSS description</description>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("iTunes subtitle"),
+            "Post-processing must override <description> with itunes:subtitle"
+        );
+    }
+
+    // TC-257-3: itunes:summary populates feed.summary, not feed.subtitle
+    #[test]
+    fn test_tc_257_3_itunes_summary_populates_feed_summary() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <description>RSS description</description>
+                <itunes:summary>iTunes summary</itunes:summary>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(feed.feed.summary.as_deref(), Some("iTunes summary"));
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("RSS description"),
+            "subtitle stays as <description> when itunes:subtitle is absent"
+        );
+    }
+
+    // TC-257-4: itunes:summary falls back to subtitle when no description present
+    #[test]
+    fn test_tc_257_4_itunes_summary_fallback_to_subtitle() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <itunes:summary>iTunes summary</itunes:summary>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(feed.feed.summary.as_deref(), Some("iTunes summary"));
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("iTunes summary"),
+            "subtitle gets summary as fallback when no <description> and no itunes:subtitle"
+        );
+    }
+
+    // TC-257-5: All three coexist — subtitle != summary != description
+    #[test]
+    fn test_tc_257_5_all_three_fields_coexist() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <description>Channel description</description>
+                <itunes:subtitle>Podcast subtitle</itunes:subtitle>
+                <itunes:summary>Podcast summary</itunes:summary>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(feed.feed.subtitle.as_deref(), Some("Podcast subtitle"));
+        assert_eq!(feed.feed.summary.as_deref(), Some("Podcast summary"));
+    }
+
+    // TC-257-6: Empty itunes:subtitle does NOT override valid <description>
+    #[test]
+    fn test_tc_257_6_empty_itunes_subtitle_no_override() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <description>Valid description</description>
+                <itunes:subtitle></itunes:subtitle>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("Valid description"),
+            "Empty itunes:subtitle must not override valid <description>"
+        );
+    }
+
+    // TC-257-7: Whitespace-only itunes:subtitle does NOT override valid <description>
+    #[test]
+    fn test_tc_257_7_whitespace_itunes_subtitle_no_override() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <description>Valid description</description>
+                <itunes:subtitle>   </itunes:subtitle>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.subtitle.as_deref(),
+            Some("Valid description"),
+            "Whitespace-only itunes:subtitle must not override valid <description>"
+        );
+    }
+
+    // TC-257-8: Entry itunes:subtitle overrides <description> for entry.subtitle
+    #[test]
+    fn test_tc_257_8_entry_itunes_subtitle_overrides_description() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel><item>
+                <description>Item description</description>
+                <itunes:subtitle>Episode subtitle</itunes:subtitle>
+            </item></channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        let entry = &feed.entries[0];
+        assert_eq!(entry.subtitle.as_deref(), Some("Episode subtitle"));
+        // <description> maps to entry.summary, itunes:subtitle maps to entry.subtitle
+        assert_eq!(entry.summary.as_deref(), Some("Item description"));
+    }
+
+    // TC-257-M3: entry itunes:summary overrides <description> for entry.summary
+    #[test]
+    fn test_tc_257_m3_entry_itunes_summary_overrides_description() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel><item>
+                <description>Item description</description>
+                <itunes:summary>Episode summary</itunes:summary>
+            </item></channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        let entry = &feed.entries[0];
+        assert_eq!(
+            entry.summary.as_deref(),
+            Some("Episode summary"),
+            "itunes:summary must override <description> for entry.summary"
+        );
+    }
+
+    // TC-281-1: itunes:complete 'Yes' returns raw string
+    #[test]
+    fn test_tc_281_1_itunes_complete_yes_raw_string() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel><title>P</title><itunes:complete>Yes</itunes:complete></channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.itunes.as_ref().unwrap().complete.as_deref(),
+            Some("Yes")
+        );
+    }
+
+    // TC-281-2: itunes:complete 'no' returns raw string
+    #[test]
+    fn test_tc_281_2_itunes_complete_no_raw_string() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel><title>P</title><itunes:complete>no</itunes:complete></channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.itunes.as_ref().unwrap().complete.as_deref(),
+            Some("no")
+        );
+    }
+
+    // TC-265-1: itunes:duration numeric stays as string (regression)
+    #[test]
+    fn test_tc_265_1_itunes_duration_numeric_stays_string() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel><item><itunes:duration>3600</itunes:duration></item></channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.entries[0].itunes.as_ref().unwrap().duration.as_deref(),
+            Some("3600")
+        );
+    }
+
+    // TC-265-2: itunes:duration H:M:S format stays as string (regression)
+    #[test]
+    fn test_tc_265_2_itunes_duration_hms_stays_string() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel><item><itunes:duration>1:00:00</itunes:duration></item></channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.entries[0].itunes.as_ref().unwrap().duration.as_deref(),
+            Some("1:00:00")
+        );
+    }
+
+    // TC-257-12: Integration — full podcast feed with all three fields
+    #[test]
+    fn test_tc_257_12_integration_full_podcast_feed() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <description>Channel description</description>
+                <itunes:subtitle>Podcast subtitle</itunes:subtitle>
+                <itunes:summary>Podcast summary</itunes:summary>
+                <itunes:complete>Yes</itunes:complete>
+                <item>
+                    <description>Episode description</description>
+                    <itunes:subtitle>Episode subtitle</itunes:subtitle>
+                    <itunes:summary>Episode summary</itunes:summary>
+                    <itunes:duration>1:23:45</itunes:duration>
+                </item>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(feed.feed.subtitle.as_deref(), Some("Podcast subtitle"));
+        assert_eq!(feed.feed.summary.as_deref(), Some("Podcast summary"));
+        assert_eq!(
+            feed.feed.itunes.as_ref().unwrap().complete.as_deref(),
+            Some("Yes")
+        );
+        let entry = &feed.entries[0];
+        assert_eq!(entry.subtitle.as_deref(), Some("Episode subtitle"));
+        assert_eq!(entry.summary.as_deref(), Some("Episode summary"));
+        assert_eq!(
+            entry.itunes.as_ref().unwrap().duration.as_deref(),
+            Some("1:23:45")
+        );
     }
 }

--- a/crates/feedparser-rs-core/src/types/feed.rs
+++ b/crates/feedparser-rs-core/src/types/feed.rs
@@ -26,6 +26,10 @@ pub struct FeedMeta {
     pub subtitle: Option<String>,
     /// Detailed subtitle with metadata
     pub subtitle_detail: Option<TextConstruct>,
+    /// Feed summary (populated from itunes:summary when present)
+    pub summary: Option<String>,
+    /// Detailed summary with metadata
+    pub summary_detail: Option<TextConstruct>,
     /// Last update date
     pub updated: Option<DateTime<Utc>>,
     /// Original update date string as found in the feed (timezone preserved)
@@ -306,6 +310,23 @@ impl FeedMeta {
     pub fn set_subtitle(&mut self, text: TextConstruct) {
         self.subtitle = Some(text.value.clone());
         self.subtitle_detail = Some(text);
+    }
+
+    /// Sets summary field with `TextConstruct`, storing both simple and detailed versions
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use feedparser_rs::{FeedMeta, TextConstruct};
+    ///
+    /// let mut meta = FeedMeta::default();
+    /// meta.set_summary(TextConstruct::text("A detailed description"));
+    /// assert_eq!(meta.summary.as_deref(), Some("A detailed description"));
+    /// ```
+    #[inline]
+    pub fn set_summary(&mut self, text: TextConstruct) {
+        self.summary = Some(text.value.clone());
+        self.summary_detail = Some(text);
     }
 
     /// Sets rights field with `TextConstruct`, storing both simple and detailed versions

--- a/crates/feedparser-rs-core/src/types/podcast.rs
+++ b/crates/feedparser-rs-core/src/types/podcast.rs
@@ -35,9 +35,8 @@ pub struct ItunesFeedMeta {
     pub podcast_type: Option<String>,
     /// Podcast completion status (itunes:complete)
     ///
-    /// Set to true if podcast is complete and no new episodes will be published.
-    /// Value is "Yes" in the feed for true.
-    pub complete: Option<bool>,
+    /// Raw XML text value from the feed (e.g., "Yes", "No").
+    pub complete: Option<String>,
     /// New feed URL for migrated podcasts (itunes:new-feed-url)
     ///
     /// Indicates the podcast has moved to a new feed location.
@@ -711,12 +710,12 @@ mod tests {
     #[test]
     fn test_itunes_feed_meta_new_fields() {
         let meta = ItunesFeedMeta {
-            complete: Some(true),
+            complete: Some("Yes".to_string()),
             new_feed_url: Some("https://example.com/new-feed.xml".to_string().into()),
             ..Default::default()
         };
 
-        assert_eq!(meta.complete, Some(true));
+        assert_eq!(meta.complete.as_deref(), Some("Yes"));
         assert_eq!(
             meta.new_feed_url.as_deref(),
             Some("https://example.com/new-feed.xml")

--- a/crates/feedparser-rs-core/tests/test_podcast_namespace.rs
+++ b/crates/feedparser-rs-core/tests/test_podcast_namespace.rs
@@ -139,7 +139,11 @@ fn test_itunes_complete_yes() {
     );
 
     let itunes = feed.feed.itunes.as_ref().unwrap();
-    assert_eq!(itunes.complete, Some(true), "Podcast should be complete");
+    assert_eq!(
+        itunes.complete.as_deref(),
+        Some("Yes"),
+        "Podcast should be complete"
+    );
 }
 
 #[test]
@@ -155,8 +159,8 @@ fn test_itunes_complete_no() {
     let feed = parse(xml.as_bytes()).expect("Failed to parse feed");
     let itunes = feed.feed.itunes.as_ref().unwrap();
     assert_eq!(
-        itunes.complete,
-        Some(false),
+        itunes.complete.as_deref(),
+        Some("No"),
         "Podcast should not be complete"
     );
 }
@@ -339,16 +343,15 @@ fn test_podcast_chapters_missing_url() {
 }
 
 #[test]
-fn test_itunes_complete_case_insensitive() {
+fn test_itunes_complete_stores_raw_string() {
+    // complete now stores the raw XML text value verbatim (trimmed), not a bool.
     let test_cases = vec![
-        ("YES", Some(true)),
-        ("yes", Some(true)),
-        ("Yes", Some(true)),
-        ("yEs", Some(true)),
-        ("NO", Some(false)),
-        ("no", Some(false)),
-        ("No", Some(false)),
-        ("nO", Some(false)),
+        ("YES", "YES"),
+        ("yes", "yes"),
+        ("Yes", "Yes"),
+        ("No", "No"),
+        ("no", "no"),
+        ("maybe", "maybe"),
     ];
 
     for (value, expected) in test_cases {
@@ -365,8 +368,9 @@ fn test_itunes_complete_case_insensitive() {
         let feed = parse(xml.as_bytes()).expect("Failed to parse feed");
         let itunes = feed.feed.itunes.as_ref().unwrap();
         assert_eq!(
-            itunes.complete, expected,
-            "complete='{value}' should parse as {expected:?}"
+            itunes.complete.as_deref(),
+            Some(expected),
+            "complete='{value}' should store raw string '{expected}'"
         );
     }
 }
@@ -384,8 +388,8 @@ fn test_itunes_complete_whitespace() {
     let feed = parse(xml.as_bytes()).expect("Failed to parse feed");
     let itunes = feed.feed.itunes.as_ref().unwrap();
     assert_eq!(
-        itunes.complete,
-        Some(true),
+        itunes.complete.as_deref(),
+        Some("Yes"),
         "Whitespace around 'Yes' should be trimmed"
     );
 }
@@ -403,9 +407,9 @@ fn test_itunes_complete_invalid_value() {
     let feed = parse(xml.as_bytes()).expect("Failed to parse feed");
     let itunes = feed.feed.itunes.as_ref().unwrap();
     assert_eq!(
-        itunes.complete,
-        Some(false),
-        "Invalid value should be treated as false"
+        itunes.complete.as_deref(),
+        Some("maybe"),
+        "Raw value should be stored verbatim"
     );
 }
 

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -319,6 +319,10 @@ pub struct FeedMeta {
     pub subtitle: Option<String>,
     /// Detailed subtitle with metadata
     pub subtitle_detail: Option<TextConstruct>,
+    /// Feed summary (populated from itunes:summary when present)
+    pub summary: Option<String>,
+    /// Detailed summary with metadata
+    pub summary_detail: Option<TextConstruct>,
     /// Last update date (original string from feed, timezone preserved)
     pub updated: Option<String>,
     /// Parsed last update date as milliseconds since epoch
@@ -404,6 +408,8 @@ impl From<CoreFeedMeta> for FeedMeta {
             links: core.links.into_iter().map(Link::from).collect(),
             subtitle: core.subtitle,
             subtitle_detail: core.subtitle_detail.map(TextConstruct::from),
+            summary: core.summary,
+            summary_detail: core.summary_detail.map(TextConstruct::from),
             updated: core.updated_str,
             updated_parsed: core.updated.map(|dt| dt.timestamp_millis() as f64),
             published: core.published_str,
@@ -1087,8 +1093,8 @@ pub struct ItunesFeedMeta {
     /// Podcast type (episodic/serial)
     #[napi(js_name = "podcastType")]
     pub podcast_type: Option<String>,
-    /// Podcast completion status
-    pub complete: Option<bool>,
+    /// Podcast completion status (raw XML text value, e.g., "Yes", "No")
+    pub complete: Option<String>,
     /// New feed URL for migrated podcasts
     ///
     /// Note: URL from untrusted feed input. Validate before fetching.

--- a/crates/feedparser-rs-py/src/types/feed_meta.rs
+++ b/crates/feedparser-rs-py/src/types/feed_meta.rs
@@ -95,6 +95,19 @@ impl PyFeedMeta {
     }
 
     #[getter]
+    fn summary(&self) -> Option<&str> {
+        self.inner.summary.as_deref()
+    }
+
+    #[getter]
+    fn summary_detail(&self) -> Option<PyTextConstruct> {
+        self.inner
+            .summary_detail
+            .as_ref()
+            .map(|tc| PyTextConstruct::from_core(tc.clone()))
+    }
+
+    #[getter]
     fn updated(&self) -> Option<&str> {
         self.inner.updated_str.as_deref()
     }
@@ -322,6 +335,8 @@ impl PyFeedMeta {
             "links",
             "subtitle",
             "subtitle_detail",
+            "summary",
+            "summary_detail",
             "updated",
             "updated_parsed",
             "published",
@@ -417,10 +432,10 @@ impl PyFeedMeta {
                     }),
                     "summary" => self
                         .inner
-                        .subtitle
+                        .summary
                         .as_deref()
                         .and_then(|v| v.into_pyobject(py).map(|o| o.unbind().into()).ok()),
-                    "summary_detail" => self.inner.subtitle_detail.as_ref().and_then(|tc| {
+                    "summary_detail" => self.inner.summary_detail.as_ref().and_then(|tc| {
                         Py::new(py, PyTextConstruct::from_core(tc.clone()))
                             .ok()
                             .map(|p: Py<PyTextConstruct>| p.into_any())
@@ -523,6 +538,20 @@ impl PyFeedMeta {
                 .unbind()),
             "subtitle_detail" => {
                 if let Some(ref tc) = self.inner.subtitle_detail {
+                    Ok(Py::new(py, PyTextConstruct::from_core(tc.clone()))?.into_any())
+                } else {
+                    Ok(py.None())
+                }
+            }
+            "summary" => Ok(self
+                .inner
+                .summary
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "summary_detail" => {
+                if let Some(ref tc) = self.inner.summary_detail {
                     Ok(Py::new(py, PyTextConstruct::from_core(tc.clone()))?.into_any())
                 } else {
                     Ok(py.None())
@@ -726,7 +755,7 @@ impl PyFeedMeta {
                 .inner
                 .itunes
                 .as_ref()
-                .and_then(|i| i.complete.map(|b| if b { "yes" } else { "no" }))
+                .and_then(|i| i.complete.as_deref())
                 .into_pyobject(py)?
                 .into_any()
                 .unbind()),
@@ -858,11 +887,11 @@ impl PyFeedMeta {
                                             .map(|p: Py<PyTextConstruct>| p.into_any())
                                     })
                                 }
-                                "summary" => self.inner.subtitle.as_deref().and_then(|v| {
+                                "summary" => self.inner.summary.as_deref().and_then(|v| {
                                     v.into_pyobject(py).map(|o| o.unbind().into()).ok()
                                 }),
                                 "summary_detail" => {
-                                    self.inner.subtitle_detail.as_ref().and_then(|tc| {
+                                    self.inner.summary_detail.as_ref().and_then(|tc| {
                                         Py::new(py, PyTextConstruct::from_core(tc.clone()))
                                             .ok()
                                             .map(|p: Py<PyTextConstruct>| p.into_any())

--- a/crates/feedparser-rs-py/src/types/podcast.rs
+++ b/crates/feedparser-rs-py/src/types/podcast.rs
@@ -65,8 +65,8 @@ impl PyItunesFeedMeta {
     }
 
     #[getter]
-    fn complete(&self) -> Option<bool> {
-        self.inner.complete
+    fn complete(&self) -> Option<&str> {
+        self.inner.complete.as_deref()
     }
 
     #[getter]
@@ -77,6 +77,16 @@ impl PyItunesFeedMeta {
     #[getter]
     fn block(&self) -> Option<u8> {
         self.inner.block
+    }
+
+    #[getter]
+    fn subtitle(&self) -> Option<&str> {
+        self.inner.subtitle.as_deref()
+    }
+
+    #[getter]
+    fn summary(&self) -> Option<&str> {
+        self.inner.summary.as_deref()
     }
 
     fn __repr__(&self) -> String {
@@ -95,9 +105,11 @@ impl PyItunesFeedMeta {
             "image" => self.inner.image.as_deref().into_py_any(py),
             "keywords" => self.inner.keywords.clone().into_py_any(py),
             "podcast_type" => self.inner.podcast_type.as_deref().into_py_any(py),
-            "complete" => self.inner.complete.into_py_any(py),
+            "complete" => self.inner.complete.as_deref().into_py_any(py),
             "new_feed_url" => self.inner.new_feed_url.as_deref().into_py_any(py),
             "block" => self.inner.block.into_py_any(py),
+            "subtitle" => self.inner.subtitle.as_deref().into_py_any(py),
+            "summary" => self.inner.summary.as_deref().into_py_any(py),
             _ => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
         }
     }
@@ -113,6 +125,8 @@ impl PyItunesFeedMeta {
                 | "complete"
                 | "new_feed_url"
                 | "block"
+                | "subtitle"
+                | "summary"
         )
     }
 
@@ -140,6 +154,8 @@ impl PyItunesFeedMeta {
             "complete",
             "new_feed_url",
             "block",
+            "subtitle",
+            "summary",
         ]
     }
 
@@ -212,6 +228,16 @@ impl PyItunesEntryMeta {
         self.inner.episode_type.as_deref()
     }
 
+    #[getter]
+    fn subtitle(&self) -> Option<&str> {
+        self.inner.subtitle.as_deref()
+    }
+
+    #[getter]
+    fn summary(&self) -> Option<&str> {
+        self.inner.summary.as_deref()
+    }
+
     fn __repr__(&self) -> String {
         if let (Some(season), Some(episode)) =
             (self.inner.season.as_deref(), self.inner.episode.as_deref())
@@ -233,6 +259,8 @@ impl PyItunesEntryMeta {
             "episode" => self.inner.episode.as_deref().into_py_any(py),
             "season" => self.inner.season.as_deref().into_py_any(py),
             "episode_type" => self.inner.episode_type.as_deref().into_py_any(py),
+            "subtitle" => self.inner.subtitle.as_deref().into_py_any(py),
+            "summary" => self.inner.summary.as_deref().into_py_any(py),
             _ => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
         }
     }
@@ -248,6 +276,8 @@ impl PyItunesEntryMeta {
                 | "episode"
                 | "season"
                 | "episode_type"
+                | "subtitle"
+                | "summary"
         )
     }
 
@@ -275,6 +305,8 @@ impl PyItunesEntryMeta {
             "episode",
             "season",
             "episode_type",
+            "subtitle",
+            "summary",
         ]
     }
 


### PR DESCRIPTION
## Summary

- `itunes:complete` now returns raw string (`'yes'`/`'no'`) instead of `bool`, matching Python feedparser API (#281)
- `feed.subtitle` overrides `<description>` with `<itunes:subtitle>` when both are present (#257)
- `feed.summary` is now populated from `<itunes:summary>` (was always `None`) (#257)
- `itunes:duration` confirmed as `String`; regression test added (#265)

## Changes

- `ItunesFeedMeta.complete`: `Option<bool>` → `Option<String>` in core, Python, and Node bindings
- `FeedMeta` gains `summary` and `summary_detail` fields
- Mandatory post-processing (`apply_itunes_feed_promotions` / `apply_itunes_entry_promotions`) in both RSS and Atom parsers ensures order-independent promotion
- Empty/whitespace iTunes values do not override valid RSS native fields
- Python `PyItunesFeedMeta` and `PyItunesEntryMeta`: dict-protocol methods restored and updated; `subtitle`/`summary` getters added

## Test plan

- 927 tests pass (`cargo nextest run`)
- New tests cover: numeric and H:M:S duration as string, complete raw string, subtitle/summary promotion with both fields present, empty-string guard (RSS and Atom), no-regression when only iTunes fields present
- `cargo +nightly fmt --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo deny check` clean

## Bozo pattern gate

- Valid feeds: `bozo = false` confirmed (existing test suite)
- Malformed input: existing bozo tests pass; no new panic paths introduced

Closes #257, #265, #281