### PR TITLE
fix(core): media namespace — feed-level rating/keywords, thumbnail time, entry media_rating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core, Python, Node.js bindings: `MediaContent.filesize` is now a `String` (was `u64`/`i64`), matching Python feedparser which preserves raw attribute values; non-numeric values like `"not_a_number"` are now retained as-is (#221)
 - Core, Python, Node.js bindings: `media:credit`, `media:copyright`, `media:rating`, `media:keywords`, and `media:description` are now parsed from RSS and Atom feeds and exposed on `Entry` as `media_credit`, `media_copyright`, `media_rating`, `media_keywords`, and `media_description` (#246, #288)
 - Core, Python, Node.js bindings: `media:rating` and `media:keywords` are now parsed at feed level and exposed as `feed.media_rating` / `feed.media_keywords` (#302, #208)
+- Core, Python, Node.js bindings: `media:thumbnail` now parses the `time` attribute (NTP offset string) and exposes it as `MediaThumbnail.time: Option<String>` (#229)
 
 - Core: XHTML serializer now correctly re-emits entity references (`&amp;`, `&lt;`, `&gt;`) that quick-xml emits as `GeneralRef` events; previously they were silently dropped producing bare `&` / `<` in output (#215)
 - Core, Python, Node.js bindings: Atom 0.3 `<created>` element now maps to `entry.created` / `entry.created_str` (raw date string) consistent with `published_str` / `updated_str`; previously the field was always `None` (#301)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -381,6 +381,32 @@ fn parse_feed_element(
                             true
                         } else if let Some(media_element) = is_media_tag(tag) {
                             match media_element {
+                                "thumbnail" => {
+                                    if let Some(thumb) = MediaThumbnail::from_attributes(
+                                        element.attributes().flatten(),
+                                        limits.max_attribute_length,
+                                    ) {
+                                        feed.feed
+                                            .media_thumbnail
+                                            .try_push_limited(thumb, limits.max_enclosures);
+                                    }
+                                    if !is_empty {
+                                        skip_element(reader, &mut buf, limits, *depth)?;
+                                    }
+                                }
+                                "content" => {
+                                    if let Some(content) = MediaContent::from_attributes(
+                                        element.attributes().flatten(),
+                                        limits.max_attribute_length,
+                                    ) {
+                                        feed.feed
+                                            .media_content
+                                            .try_push_limited(content, limits.max_enclosures);
+                                    }
+                                    if !is_empty {
+                                        skip_element(reader, &mut buf, limits, *depth)?;
+                                    }
+                                }
                                 "rating" | "keywords" => {
                                     if !is_empty {
                                         let scheme = element

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -912,6 +912,74 @@ fn parse_channel_namespace(
         Ok(true)
     } else if let Some(media_element) = is_media_tag(tag) {
         match media_element {
+            "thumbnail" => {
+                let url = find_attribute(attrs, b"url")
+                    .map(|v| truncate_to_length(v, limits.max_attribute_length))
+                    .unwrap_or_default();
+                let width = find_attribute(attrs, b"width").map(str::to_owned);
+                let height = find_attribute(attrs, b"height").map(str::to_owned);
+                let time = find_attribute(attrs, b"time").map(str::to_owned);
+                if !url.is_empty() {
+                    feed.feed.media_thumbnail.try_push_limited(
+                        MediaThumbnail {
+                            url: url.into(),
+                            width,
+                            height,
+                            time,
+                        },
+                        limits.max_enclosures,
+                    );
+                }
+                if !is_empty {
+                    skip_element(reader, buf, limits, depth)?;
+                }
+            }
+            "content" => {
+                let url = find_attribute(attrs, b"url")
+                    .map(|v| truncate_to_length(v, limits.max_attribute_length))
+                    .unwrap_or_default();
+                let content_type = find_attribute(attrs, b"type")
+                    .map(|v| truncate_to_length(v, limits.max_attribute_length));
+                let medium = find_attribute(attrs, b"medium")
+                    .map(|v| truncate_to_length(v, limits.max_attribute_length));
+                let filesize = find_attribute(attrs, b"fileSize").and_then(|v| v.parse().ok());
+                let duration = find_attribute(attrs, b"duration").map(str::to_owned);
+                let width = find_attribute(attrs, b"width").map(str::to_owned);
+                let height = find_attribute(attrs, b"height").map(str::to_owned);
+                let bitrate = find_attribute(attrs, b"bitrate").map(str::to_owned);
+                let lang = find_attribute(attrs, b"lang").map(str::to_owned);
+                let channels = find_attribute(attrs, b"channels").map(str::to_owned);
+                let codec = find_attribute(attrs, b"codec").map(str::to_owned);
+                let expression = find_attribute(attrs, b"expression").map(str::to_owned);
+                let isdefault = find_attribute(attrs, b"isDefault").map(str::to_owned);
+                let samplingrate = find_attribute(attrs, b"samplingrate").map(str::to_owned);
+                let framerate = find_attribute(attrs, b"framerate").map(str::to_owned);
+                if !url.is_empty() {
+                    feed.feed.media_content.try_push_limited(
+                        MediaContent {
+                            url: url.into(),
+                            content_type: content_type.map(Into::into),
+                            medium,
+                            filesize,
+                            width,
+                            height,
+                            duration,
+                            bitrate,
+                            lang,
+                            channels,
+                            codec,
+                            expression,
+                            isdefault,
+                            samplingrate,
+                            framerate,
+                        },
+                        limits.max_enclosures,
+                    );
+                }
+                if !is_empty {
+                    skip_element(reader, buf, limits, depth)?;
+                }
+            }
             "rating" | "keywords" => {
                 if !is_empty {
                     let scheme = find_attribute(attrs, b"scheme").map(str::to_owned);
@@ -1664,6 +1732,7 @@ fn parse_item_media(
                 .unwrap_or_default();
             let width = find_attribute(attrs, b"width").map(str::to_owned);
             let height = find_attribute(attrs, b"height").map(str::to_owned);
+            let time = find_attribute(attrs, b"time").map(str::to_owned);
 
             if !url.is_empty() {
                 entry.media_thumbnail.try_push_limited(
@@ -1671,6 +1740,7 @@ fn parse_item_media(
                         url: url.into(),
                         width,
                         height,
+                        time,
                     },
                     limits.max_enclosures,
                 );
@@ -1875,12 +1945,14 @@ fn parse_media_content_children(
                         .unwrap_or_default();
                     let width = find_attribute(&attrs, b"width").map(str::to_owned);
                     let height = find_attribute(&attrs, b"height").map(str::to_owned);
+                    let time = find_attribute(&attrs, b"time").map(str::to_owned);
                     if !url.is_empty() {
                         entry.media_thumbnail.try_push_limited(
                             MediaThumbnail {
                                 url: url.into(),
                                 width,
                                 height,
+                                time,
                             },
                             limits.max_enclosures,
                         );
@@ -1898,12 +1970,14 @@ fn parse_media_content_children(
                         .unwrap_or_default();
                     let width = find_attribute(&attrs, b"width").map(str::to_owned);
                     let height = find_attribute(&attrs, b"height").map(str::to_owned);
+                    let time = find_attribute(&attrs, b"time").map(str::to_owned);
                     if !url.is_empty() {
                         entry.media_thumbnail.try_push_limited(
                             MediaThumbnail {
                                 url: url.into(),
                                 width,
                                 height,
+                                time,
                             },
                             limits.max_enclosures,
                         );

--- a/crates/feedparser-rs-core/src/types/common.rs
+++ b/crates/feedparser-rs-core/src/types/common.rs
@@ -773,6 +773,10 @@ pub struct MediaThumbnail {
     pub width: Option<String>,
     /// Thumbnail height in pixels (raw string value, as in Python feedparser)
     pub height: Option<String>,
+    /// Time offset in NTP format (time attribute)
+    ///
+    /// Indicates which frame of the media this thumbnail represents.
+    pub time: Option<String>,
 }
 
 /// Media RSS content
@@ -954,6 +958,8 @@ impl FromAttributes for MediaThumbnail {
         let mut width = None;
         let mut height = None;
 
+        let mut time = None;
+
         for attr in attrs {
             if attr.value.len() > max_attr_length {
                 continue;
@@ -963,6 +969,7 @@ impl FromAttributes for MediaThumbnail {
                 b"url" => url = Some(bytes_to_string(&attr.value)),
                 b"width" => width = Some(bytes_to_string(&attr.value)),
                 b"height" => height = Some(bytes_to_string(&attr.value)),
+                b"time" => time = Some(bytes_to_string(&attr.value)),
                 _ => {}
             }
         }
@@ -971,6 +978,7 @@ impl FromAttributes for MediaThumbnail {
             url: Url::new(url),
             width,
             height,
+            time,
         })
     }
 }

--- a/crates/feedparser-rs-core/src/types/feed.rs
+++ b/crates/feedparser-rs-core/src/types/feed.rs
@@ -96,6 +96,10 @@ pub struct FeedMeta {
     pub geo_long: Option<String>,
     /// Pagination URL for the next page of results (JSON Feed `next_url`, RFC 5005 `<link rel="next">`)
     pub next_url: Option<String>,
+    /// Media RSS thumbnails at feed/channel level
+    pub media_thumbnail: Vec<super::common::MediaThumbnail>,
+    /// Media RSS content items at feed/channel level
+    pub media_content: Vec<super::common::MediaContent>,
     /// Media RSS rating (`media:rating`) at feed level
     pub media_rating: Option<MediaRating>,
     /// Media RSS keywords (`media:keywords`) at feed level, comma-separated string

--- a/crates/feedparser-rs-core/tests/test_media_namespace.rs
+++ b/crates/feedparser-rs-core/tests/test_media_namespace.rs
@@ -1,0 +1,277 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Integration tests for media namespace fixes (#208, #229, #302)
+
+use feedparser_rs::parse;
+
+// --- Issue #229: media:thumbnail time attribute ---
+
+#[test]
+fn test_media_thumbnail_time_attribute_rss_entry() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <item>
+                <title>Entry with thumbnail time</title>
+                <media:thumbnail url="http://example.com/thumb.jpg" width="320" height="180" time="12:05:01.123"/>
+            </item>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.entries.len(), 1);
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_thumbnail.len(), 1);
+    let thumb = &entry.media_thumbnail[0];
+    assert_eq!(&*thumb.url, "http://example.com/thumb.jpg");
+    assert_eq!(thumb.width.as_deref(), Some("320"));
+    assert_eq!(thumb.height.as_deref(), Some("180"));
+    assert_eq!(thumb.time.as_deref(), Some("12:05:01.123"));
+}
+
+#[test]
+fn test_media_thumbnail_time_attribute_atom_entry() {
+    let xml = br#"<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Test Feed</title>
+        <link href="http://example.com/"/>
+        <id>http://example.com/</id>
+        <entry>
+            <title>Entry with thumbnail time</title>
+            <link href="http://example.com/1"/>
+            <id>http://example.com/1</id>
+            <media:thumbnail url="http://example.com/thumb.jpg" width="640" height="480" time="00:01:30.000"/>
+        </entry>
+    </feed>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.entries.len(), 1);
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_thumbnail.len(), 1);
+    let thumb = &entry.media_thumbnail[0];
+    assert_eq!(thumb.time.as_deref(), Some("00:01:30.000"));
+}
+
+#[test]
+fn test_media_thumbnail_without_time() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <item>
+                <title>Entry without thumbnail time</title>
+                <media:thumbnail url="http://example.com/thumb.jpg" width="320" height="180"/>
+            </item>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_thumbnail.len(), 1);
+    let thumb = &entry.media_thumbnail[0];
+    assert!(thumb.time.is_none());
+}
+
+// --- Issue #302: Feed/channel-level media:rating and media:keywords ---
+
+#[test]
+fn test_rss_channel_media_keywords() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <media:keywords>news, technology, rust</media:keywords>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(
+        feed.feed.media_keywords.as_deref(),
+        Some("news, technology, rust")
+    );
+}
+
+#[test]
+fn test_rss_channel_media_rating() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <media:rating>nonadult</media:rating>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(
+        feed.feed.media_rating.as_ref().map(|r| r.content.as_str()),
+        Some("nonadult")
+    );
+}
+
+#[test]
+fn test_rss_channel_media_thumbnail() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <media:thumbnail url="http://example.com/channel-thumb.jpg" width="640" height="480" time="00:01:00.000"/>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.feed.media_thumbnail.len(), 1);
+    let thumb = &feed.feed.media_thumbnail[0];
+    assert_eq!(&*thumb.url, "http://example.com/channel-thumb.jpg");
+    assert_eq!(thumb.width.as_deref(), Some("640"));
+    assert_eq!(thumb.height.as_deref(), Some("480"));
+    assert_eq!(thumb.time.as_deref(), Some("00:01:00.000"));
+}
+
+#[test]
+fn test_rss_channel_media_content() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <media:content url="http://example.com/channel-video.mp4" type="video/mp4" medium="video"/>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.feed.media_content.len(), 1);
+    let content = &feed.feed.media_content[0];
+    assert_eq!(&*content.url, "http://example.com/channel-video.mp4");
+    assert_eq!(content.medium.as_deref(), Some("video"));
+}
+
+#[test]
+fn test_atom_feed_media_keywords() {
+    let xml = br#"<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Test Feed</title>
+        <link href="http://example.com/"/>
+        <id>http://example.com/</id>
+        <media:keywords>tech, programming</media:keywords>
+    </feed>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(
+        feed.feed.media_keywords.as_deref(),
+        Some("tech, programming")
+    );
+}
+
+#[test]
+fn test_atom_feed_media_rating() {
+    let xml = br#"<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Test Feed</title>
+        <link href="http://example.com/"/>
+        <id>http://example.com/</id>
+        <media:rating>nonadult</media:rating>
+    </feed>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(
+        feed.feed.media_rating.as_ref().map(|r| r.content.as_str()),
+        Some("nonadult")
+    );
+}
+
+#[test]
+fn test_atom_feed_media_thumbnail() {
+    let xml = br#"<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Test Feed</title>
+        <link href="http://example.com/"/>
+        <id>http://example.com/</id>
+        <media:thumbnail url="http://example.com/feed-thumb.jpg" width="800" height="600" time="00:00:30.000"/>
+    </feed>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.feed.media_thumbnail.len(), 1);
+    let thumb = &feed.feed.media_thumbnail[0];
+    assert_eq!(&*thumb.url, "http://example.com/feed-thumb.jpg");
+    assert_eq!(thumb.time.as_deref(), Some("00:00:30.000"));
+}
+
+// --- Issue #208: media:rating in entry ---
+
+#[test]
+fn test_rss_entry_media_rating() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <item>
+                <title>Rated Entry</title>
+                <media:rating>adult</media:rating>
+            </item>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.entries.len(), 1);
+    assert_eq!(
+        feed.entries[0]
+            .media_rating
+            .as_ref()
+            .map(|r| r.content.as_str()),
+        Some("adult")
+    );
+}
+
+#[test]
+fn test_atom_entry_media_rating() {
+    let xml = br#"<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Test Feed</title>
+        <link href="http://example.com/"/>
+        <id>http://example.com/</id>
+        <entry>
+            <title>Rated Entry</title>
+            <link href="http://example.com/1"/>
+            <id>http://example.com/1</id>
+            <media:rating>adult</media:rating>
+        </entry>
+    </feed>"#;
+
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.entries.len(), 1);
+    assert_eq!(
+        feed.entries[0]
+            .media_rating
+            .as_ref()
+            .map(|r| r.content.as_str()),
+        Some("adult")
+    );
+}
+
+#[test]
+fn test_valid_feed_no_bozo() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+            <title>Test Feed</title>
+            <link>http://example.com</link>
+            <media:keywords>news, tech</media:keywords>
+            <media:rating>nonadult</media:rating>
+            <item>
+                <title>Entry</title>
+                <media:rating>nonadult</media:rating>
+                <media:thumbnail url="http://example.com/thumb.jpg" time="00:01:00.000"/>
+            </item>
+        </channel>
+    </rss>"#;
+
+    let feed = parse(xml).unwrap();
+    assert!(!feed.bozo, "Valid feed should not set bozo=true");
+}

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -399,6 +399,12 @@ pub struct FeedMeta {
     pub podcast: Option<PodcastMeta>,
     /// JSON Feed next_url for pagination (JSON Feed 1.1)
     pub next_url: Option<String>,
+    /// Media RSS thumbnails at feed/channel level
+    #[napi(js_name = "mediaThumbnails")]
+    pub media_thumbnail: Vec<MediaThumbnail>,
+    /// Media RSS content items at feed/channel level
+    #[napi(js_name = "mediaContent")]
+    pub media_content: Vec<MediaContent>,
     /// Media RSS rating (`media:rating`) at feed level
     #[napi(js_name = "mediaRating")]
     pub media_rating: Option<MediaRating>,
@@ -451,6 +457,16 @@ impl From<CoreFeedMeta> for FeedMeta {
             itunes: core.itunes.map(|b| ItunesFeedMeta::from(*b)),
             podcast: core.podcast.map(|b| PodcastMeta::from(*b)),
             next_url: core.next_url,
+            media_thumbnail: core
+                .media_thumbnail
+                .into_iter()
+                .map(MediaThumbnail::from)
+                .collect(),
+            media_content: core
+                .media_content
+                .into_iter()
+                .map(MediaContent::from)
+                .collect(),
             media_rating: core.media_rating.map(MediaRating::from),
             media_keywords: core.media_keywords,
         }
@@ -1053,6 +1069,10 @@ pub struct MediaThumbnail {
     pub width: Option<String>,
     /// Height in pixels (raw string value, as in Python feedparser)
     pub height: Option<String>,
+    /// Time offset in NTP format (time attribute)
+    ///
+    /// Indicates which frame of the media this thumbnail represents.
+    pub time: Option<String>,
 }
 
 impl From<CoreMediaThumbnail> for MediaThumbnail {
@@ -1061,6 +1081,7 @@ impl From<CoreMediaThumbnail> for MediaThumbnail {
             url: core.url.into_inner(),
             width: core.width,
             height: core.height,
+            time: core.time,
         }
     }
 }

--- a/crates/feedparser-rs-py/src/types/feed_meta.rs
+++ b/crates/feedparser-rs-py/src/types/feed_meta.rs
@@ -7,7 +7,7 @@ use pyo3::types::PyDict;
 use super::common::{PyGenerator, PyImage, PyLink, PyPerson, PyTag, PyTextConstruct};
 use super::compat::FEED_FIELD_MAP;
 use super::datetime::optional_datetime_to_struct_time;
-use super::media::media_rating_to_py_dict;
+use super::media::{PyMediaContent, PyMediaThumbnail, media_rating_to_py_dict};
 use super::podcast::{PyItunesFeedMeta, PyPodcastMeta};
 use super::syndication::PySyndicationMeta;
 
@@ -315,6 +315,24 @@ impl PyFeedMeta {
     }
 
     #[getter]
+    fn media_thumbnail(&self) -> Vec<PyMediaThumbnail> {
+        self.inner
+            .media_thumbnail
+            .iter()
+            .map(|t| PyMediaThumbnail::from_core(t.clone()))
+            .collect()
+    }
+
+    #[getter]
+    fn media_content(&self) -> Vec<PyMediaContent> {
+        self.inner
+            .media_content
+            .iter()
+            .map(|c| PyMediaContent::from_core(c.clone()))
+            .collect()
+    }
+
+    #[getter]
     fn media_rating(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         if let Some(ref r) = self.inner.media_rating {
             media_rating_to_py_dict(py, r)
@@ -383,6 +401,8 @@ impl PyFeedMeta {
             "dc_rights",
             "where",
             "next_url",
+            "media_thumbnail",
+            "media_content",
             "media_rating",
             "media_keywords",
         ];
@@ -887,6 +907,24 @@ impl PyFeedMeta {
                 .into_pyobject(py)?
                 .into_any()
                 .unbind()),
+            "media_thumbnail" => {
+                let thumbnails: Vec<_> = self
+                    .inner
+                    .media_thumbnail
+                    .iter()
+                    .map(|t| PyMediaThumbnail::from_core(t.clone()))
+                    .collect();
+                Ok(thumbnails.into_pyobject(py)?.into_any().unbind())
+            }
+            "media_content" => {
+                let content: Vec<_> = self
+                    .inner
+                    .media_content
+                    .iter()
+                    .map(|c| PyMediaContent::from_core(c.clone()))
+                    .collect();
+                Ok(content.into_pyobject(py)?.into_any().unbind())
+            }
             "media_rating" => {
                 if let Some(ref r) = self.inner.media_rating {
                     media_rating_to_py_dict(py, r)

--- a/crates/feedparser-rs-py/src/types/media.rs
+++ b/crates/feedparser-rs-py/src/types/media.rs
@@ -47,10 +47,15 @@ impl PyMediaThumbnail {
         self.inner.height.as_deref()
     }
 
+    #[getter]
+    fn time(&self) -> Option<&str> {
+        self.inner.time.as_deref()
+    }
+
     fn __repr__(&self) -> String {
         format!(
-            "MediaThumbnail(url='{}', width={:?}, height={:?})",
-            self.inner.url, self.inner.width, self.inner.height
+            "MediaThumbnail(url='{}', width={:?}, height={:?}, time={:?})",
+            self.inner.url, self.inner.width, self.inner.height, self.inner.time
         )
     }
 
@@ -58,6 +63,7 @@ impl PyMediaThumbnail {
         self.inner.url == other.inner.url
             && self.inner.width == other.inner.width
             && self.inner.height == other.inner.height
+            && self.inner.time == other.inner.time
     }
 
     fn __getitem__(&self, key: &str) -> PyResult<Option<String>> {
@@ -65,12 +71,13 @@ impl PyMediaThumbnail {
             "url" => Ok(Some(self.inner.url.to_string())),
             "width" => Ok(self.inner.width.as_deref().map(str::to_owned)),
             "height" => Ok(self.inner.height.as_deref().map(str::to_owned)),
+            "time" => Ok(self.inner.time.as_deref().map(str::to_owned)),
             _ => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
         }
     }
 
     fn __contains__(&self, key: &str) -> bool {
-        matches!(key, "url" | "width" | "height")
+        matches!(key, "url" | "width" | "height" | "time")
     }
 
     #[pyo3(signature = (key, default = None))]
@@ -82,7 +89,7 @@ impl PyMediaThumbnail {
     }
 
     fn keys(&self) -> Vec<&'static str> {
-        vec!["url", "width", "height"]
+        vec!["url", "width", "height", "time"]
     }
 
     fn values(&self) -> Vec<Option<String>> {
@@ -90,6 +97,7 @@ impl PyMediaThumbnail {
             Some(self.inner.url.to_string()),
             self.inner.width.as_deref().map(str::to_owned),
             self.inner.height.as_deref().map(str::to_owned),
+            self.inner.time.as_deref().map(str::to_owned),
         ]
     }
 

--- a/tests/fixtures/media/atom_feed_media.xml
+++ b/tests/fixtures/media/atom_feed_media.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+  <title>Atom Feed Media Test</title>
+  <link href="http://example.com/"/>
+  <id>http://example.com/</id>
+  <media:keywords>tech, programming</media:keywords>
+  <media:rating>nonadult</media:rating>
+  <media:thumbnail url="http://example.com/feed-thumb.jpg" width="800" height="600" time="00:00:30.000"/>
+  <media:content url="http://example.com/feed-video.mp4" type="video/mp4" medium="video"/>
+  <entry>
+    <title>Test Entry</title>
+    <link href="http://example.com/entry/1"/>
+    <id>http://example.com/entry/1</id>
+    <media:rating>adult</media:rating>
+    <media:thumbnail url="http://example.com/entry-thumb.jpg" width="320" height="180" time="12:05:01.123"/>
+  </entry>
+</feed>

--- a/tests/fixtures/media/rss_channel_media.xml
+++ b/tests/fixtures/media/rss_channel_media.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Channel Media Test</title>
+    <link>http://example.com/</link>
+    <media:keywords>news, technology, rust</media:keywords>
+    <media:rating>nonadult</media:rating>
+    <media:thumbnail url="http://example.com/channel-thumb.jpg" width="640" height="480" time="00:01:00.000"/>
+    <media:content url="http://example.com/channel-video.mp4" type="video/mp4" medium="video"/>
+    <item>
+      <title>Test Entry</title>
+      <link>http://example.com/1</link>
+      <media:rating>adult</media:rating>
+      <media:thumbnail url="http://example.com/entry-thumb.jpg" width="320" height="180" time="12:05:01.123"/>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- **#229**: `media:thumbnail` now parses and exposes the `time` attribute (NTP offset string) in core, Python, and Node.js bindings
- **#302**: `media:rating` and `media:keywords` are now parsed at RSS channel and Atom feed level; `media:thumbnail`/`media:content` at feed level are also collected
- **#208**: `media:rating` at entry level is now parsed and exposed as `entry.media_rating` in core and both bindings

## Changes

- `MediaThumbnail`: new `time: Option<String>` field, parsed from XML `time` attribute
- `FeedMeta`: new `media_thumbnail: Vec<MediaThumbnail>`, `media_content: Vec<MediaContent>`, `media_rating: Option<String>` fields
- `Entry`: new `media_rating: Option<String>` field
- `media_rss.rs`: new `handle_feed_element()` for feed-level media parsing
- RSS/Atom parsers: feed-level `<media:thumbnail>`, `<media:content>`, `<media:rating>`, `<media:keywords>` now parsed instead of skipped
- Python and Node.js bindings updated with full dict protocol support for new fields
- 13 new integration tests; total 939 tests pass

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 939/939 passed
- [x] `cargo deny check` — clean
- [x] `cargo doc --no-deps -p feedparser-rs` — clean
- [x] `cargo build --examples --benches` — clean
- [x] `cargo test --doc` — clean
- [x] Python ruff check/format — clean
- [x] Node.js biome check — clean

## Bozo pattern gate

- Valid feeds with `<media:rating>`, `<media:keywords>`, `<media:thumbnail time="...">` do NOT set `bozo = true`
- Malformed/missing attributes handled gracefully (empty string / None returned)