### PR TITLE
fix(core): xhtml entity re-escaping, Atom 0.3 created field, ASCTIME date format (#215, #301, #258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core, Python, Node.js bindings: `media:credit`, `media:copyright`, `media:rating`, `media:keywords`, and `media:description` are now parsed from RSS and Atom feeds and exposed on `Entry` as `media_credit`, `media_copyright`, `media_rating`, `media_keywords`, and `media_description` (#246, #288)
 - Core, Python, Node.js bindings: `media:rating` and `media:keywords` are now parsed at feed level and exposed as `feed.media_rating` / `feed.media_keywords` (#302, #208)
 
+- Core: XHTML serializer now correctly re-emits entity references (`&amp;`, `&lt;`, `&gt;`) that quick-xml emits as `GeneralRef` events; previously they were silently dropped producing bare `&` / `<` in output (#215)
+- Core, Python, Node.js bindings: Atom 0.3 `<created>` element now maps to `entry.created` / `entry.created_str` (raw date string) consistent with `published_str` / `updated_str`; previously the field was always `None` (#301)
+- Core: date parser now handles ASCTIME format `Www Mmm [D]D HH:MM:SS YYYY` with optional space-padded single-digit day (e.g. `Mon Jan  6 12:30:00 2025`) (#258)
+- Core: `Entry.created_str` field added to preserve raw Atom 0.3 `<created>` date string (#301)
 - Core: `media:content` attributes `bitrate`, `channels`, `samplingrate`, and `framerate` are now parsed and exposed as strings on `MediaContent`, matching Python feedparser behavior (#294, #253)
 - Core, Python, Node.js bindings: `media:thumbnail` elements nested inside `<media:content>` are now collected into `entry.media_thumbnail` alongside top-level thumbnails, matching Python feedparser behavior (#270)
 - Python bindings: `bitrate`, `channels`, `samplingrate`, `framerate`, `lang`, `codec`, `expression`, and `isdefault` attributes are now accessible via `MediaContent.__getitem__` / `__contains__` / `keys` / `values` dict protocol (#294)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -662,6 +662,11 @@ fn parse_entry(
                         entry.published = parse_date(&text);
                         entry.published_str = Some(text);
                     }
+                    b"created" if !is_empty => {
+                        let text = read_text_str(reader, buf, limits)?;
+                        entry.created = parse_date(&text);
+                        entry.created_str = Some(text);
+                    }
                     b"subtitle" if !is_empty => {
                         let text = parse_text_construct(reader, buf, &element, limits, entry_lang)?;
                         entry.set_subtitle(text);
@@ -3133,6 +3138,36 @@ mod tests {
             Some("Valid Atom subtitle"),
             "Empty itunes:subtitle must not override valid Atom <subtitle>"
         );
+    }
+
+    // Bug #301: Atom 0.3 <created> element maps to entry.created / entry.created_str
+    #[test]
+    fn test_atom03_created_element() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://purl.org/atom/ns#">
+            <title>Test</title>
+            <modified>2025-01-01T00:00:00Z</modified>
+            <entry>
+                <title>Entry</title>
+                <id>urn:test:1</id>
+                <issued>2024-12-01T00:00:00Z</issued>
+                <modified>2024-12-02T00:00:00Z</modified>
+                <created>2024-11-30T00:00:00Z</created>
+            </entry>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        let entry = &feed.entries[0];
+        assert!(
+            entry.created.is_some(),
+            "entry.created must be set from <created>"
+        );
+        assert_eq!(
+            entry.created_str.as_deref(),
+            Some("2024-11-30T00:00:00Z"),
+            "entry.created_str must preserve raw date string"
+        );
+        // 2024-11-30 00:00:00 UTC
+        assert_eq!(entry.created.unwrap().timestamp(), 1_732_924_800);
     }
 
     // TC-257-12B: Atom — itunes:subtitle only present (no <subtitle>) sets feed.subtitle

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -12,6 +12,7 @@ use quick_xml::{
     Reader,
     events::{BytesRef, Event},
 };
+use std::io::Write as _;
 
 pub use crate::types::{FromAttributes, LimitedCollectionExt};
 pub use crate::util::text::bytes_to_string;
@@ -680,6 +681,15 @@ fn serialize_inner_xml(
                 Ok(Event::Text(e)) => {
                     let _ = writer.write_event(Event::Text(e));
                 }
+                Ok(Event::GeneralRef(e)) => {
+                    // Entity references (e.g. &amp;, &lt;) are emitted as separate
+                    // GeneralRef events by quick-xml. Re-emit them verbatim so that
+                    // &amp; → &amp; (not lost) in the serialized XHTML output.
+                    let inner = writer.get_mut();
+                    let _ = inner.write_all(b"&");
+                    let _ = inner.write_all(e.as_ref());
+                    let _ = inner.write_all(b";");
+                }
                 Ok(Event::CData(e)) => {
                     let _ = writer.write_event(Event::CData(e));
                 }
@@ -1057,6 +1067,30 @@ mod tests {
         assert!(result.contains("<li>B</li>"));
         assert!(!result.contains("<div"));
         assert!(!had_bozo);
+    }
+
+    #[test]
+    fn test_read_xhtml_content_preserves_entities() {
+        // Bug #215: &amp; and &lt; must survive the round-trip through serialize_inner_xml
+        let xml = b"<content type=\"xhtml\"><div xmlns=\"http://www.w3.org/1999/xhtml\"><p>Tom &amp; Jerry &lt;rocks&gt;</p></div></content>";
+        let mut reader = Reader::from_reader(&xml[..]);
+        let mut buf = Vec::new();
+        advance_past_start_xhtml(&mut reader, &mut buf);
+        let (result, had_bozo) =
+            read_xhtml_content(&mut reader, &mut buf, &ParserLimits::default()).unwrap();
+        assert!(!had_bozo);
+        assert!(
+            result.contains("&amp;"),
+            "& must be escaped as &amp; in output, got: {result}"
+        );
+        assert!(
+            result.contains("&lt;"),
+            "< must be escaped as &lt; in output, got: {result}"
+        );
+        assert!(
+            !result.contains("Tom & Jerry"),
+            "bare & must not appear in output, got: {result}"
+        );
     }
 
     #[test]

--- a/crates/feedparser-rs-core/src/types/entry.rs
+++ b/crates/feedparser-rs-core/src/types/entry.rs
@@ -46,6 +46,8 @@ pub struct Entry {
     pub updated_str: Option<String>,
     /// Creation date
     pub created: Option<DateTime<Utc>>,
+    /// Original creation date string as found in the feed (timezone preserved)
+    pub created_str: Option<String>,
     /// Expiration date
     pub expired: Option<DateTime<Utc>>,
     /// Primary author name (stored inline for names ≤24 bytes)

--- a/crates/feedparser-rs-core/src/util/date.rs
+++ b/crates/feedparser-rs-core/src/util/date.rs
@@ -40,6 +40,39 @@ const DATE_FORMATS: &[&str] = &[
     "%d-%B-%Y",          // 14-December-2024
 ];
 
+/// Parse ASCTIME format: `Www Mmm [D]D HH:MM:SS YYYY` where DD may have a leading space.
+///
+/// Example: `Mon Jan  6 12:30:00 2025` or `Mon Jan 16 12:30:00 2025`
+fn parse_asctime(s: &str) -> Option<NaiveDateTime> {
+    // Expected: 3 alpha (weekday) + space + 3 alpha (month) + space + 1-2 digit day
+    //           (possibly space-padded) + space + HH:MM:SS + space + YYYY
+    let b = s.as_bytes();
+    if b.len() < 24 {
+        return None;
+    }
+    // Weekday: bytes 0..3 must be alpha
+    if !b[..3].iter().all(u8::is_ascii_alphabetic) || b[3] != b' ' {
+        return None;
+    }
+    // Strip weekday prefix
+    let rest = &s[4..];
+    // Normalize: collapse double-space before single-digit day to single space
+    // "Jan  6" → "Jan 6"
+    let normalized = if rest.len() > 4 && rest.as_bytes()[4] == b' ' && rest.as_bytes()[3] == b' ' {
+        // "Mmm  D ..." → "Mmm D ..."
+        let mut n = String::with_capacity(rest.len());
+        n.push_str(&rest[..3]); // month
+        n.push(' ');
+        n.push_str(rest[4..].trim_start_matches(' '));
+        n
+    } else {
+        rest.to_string()
+    };
+    NaiveDateTime::parse_from_str(&normalized, "%b %e %H:%M:%S %Y")
+        .or_else(|_| NaiveDateTime::parse_from_str(&normalized, "%b %d %H:%M:%S %Y"))
+        .ok()
+}
+
 /// Strip a leading weekday prefix of the form `"Www, "` (3 ASCII alpha chars + ", ").
 fn strip_weekday_prefix(s: &str) -> Option<&str> {
     let b = s.as_bytes();
@@ -128,6 +161,11 @@ pub fn parse_date(input: &str) -> Option<DateTime<Utc>> {
         return NaiveDate::from_ymd_opt(year, month, 1)
             .and_then(|d| d.and_hms_opt(0, 0, 0))
             .map(|dt| dt.and_utc());
+    }
+
+    // Try ASCTIME format: "Mon Jan  6 12:30:00 2025"
+    if let Some(dt) = parse_asctime(input) {
+        return Some(dt.and_utc());
     }
 
     // Try all format strings
@@ -425,5 +463,33 @@ mod tests {
             assert_eq!(dt.month(), month, "Month mismatch for: {input}");
             assert_eq!(dt.day(), day, "Day mismatch for: {input}");
         }
+    }
+
+    #[test]
+    fn test_asctime_single_digit_day_space_padded() {
+        // Bug #258: "Mon Jan  6 12:30:00 2025" — day padded with space
+        let dt = parse_date("Mon Jan  6 12:30:00 2025").unwrap();
+        assert_eq!(dt.year(), 2025);
+        assert_eq!(dt.month(), 1);
+        assert_eq!(dt.day(), 6);
+        assert_eq!(dt.hour(), 12);
+        assert_eq!(dt.minute(), 30);
+        assert_eq!(dt.second(), 0);
+    }
+
+    #[test]
+    fn test_asctime_double_digit_day() {
+        let dt = parse_date("Mon Jan 16 12:30:00 2025").unwrap();
+        assert_eq!(dt.year(), 2025);
+        assert_eq!(dt.month(), 1);
+        assert_eq!(dt.day(), 16);
+    }
+
+    #[test]
+    fn test_asctime_various_months() {
+        let dt = parse_date("Fri Dec 31 23:59:59 2021").unwrap();
+        assert_eq!(dt.year(), 2021);
+        assert_eq!(dt.month(), 12);
+        assert_eq!(dt.day(), 31);
     }
 }

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -662,7 +662,7 @@ impl From<CoreEntry> for Entry {
             published_parsed: core.published.map(|dt| dt.timestamp_millis() as f64),
             updated: core.updated_str,
             updated_parsed: core.updated.map(|dt| dt.timestamp_millis() as f64),
-            created: core.created.as_ref().map(|dt| dt.to_rfc3339()),
+            created: core.created_str.clone(),
             created_parsed: core.created.map(|dt| dt.timestamp_millis() as f64),
             expired: core.expired.as_ref().map(|dt| dt.to_rfc3339()),
             expired_parsed: core.expired.map(|dt| dt.timestamp_millis() as f64),

--- a/crates/feedparser-rs-py/src/types/entry.rs
+++ b/crates/feedparser-rs-py/src/types/entry.rs
@@ -147,8 +147,8 @@ impl PyEntry {
     }
 
     #[getter]
-    fn created(&self) -> Option<String> {
-        self.inner.created.map(|dt| dt.to_rfc3339())
+    fn created(&self) -> Option<&str> {
+        self.inner.created_str.as_deref()
     }
 
     #[getter]


### PR DESCRIPTION
## Summary

- **#215**: XHTML serializer was silently dropping entity references (`&amp;`, `&lt;`, `&gt;`) emitted as `GeneralRef` events by quick-xml. Fixed by handling `Event::GeneralRef(e)` and writing `&{name};` back to the output.
- **#301**: Atom 0.3 `<created>` element was not mapped to `entry.created`. Added handler in atom.rs alongside existing `<issued>` and `<modified>` handlers; added `created_str` field for raw string; updated Python and Node.js bindings.
- **#258**: ASCTIME date format (`Mon Jan  6 12:30:00 2025`) not parsed. Added `parse_asctime()` helper normalising space-padded single-digit days before parsing.

## Test plan

- [ ] 946 tests pass (`cargo nextest run`)
- [ ] `cargo +nightly fmt --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] Bozo gate: valid feeds do not set `bozo = true`; malformed input triggers bozo and partial data is preserved

Closes #215, #301, #258