### PR TITLE
fix(core): re-escape HTML entities in xhtml content text nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Core: HTML entities (`&amp;`, `&lt;`, `&gt;`) in `type="xhtml"` Atom content text nodes are now preserved correctly in the serialized output (#215)
+
 - Core, Python, Node.js bindings: `media:rating` is now parsed at both feed level and entry level with `scheme` attribute; exposed as `feed.media_rating` / `entry.media_rating` dict `{"scheme": ..., "content": ...}` (#302, #208)
 - Core, Python, Node.js bindings: `media:keywords` is now parsed at feed level and exposed as `feed.media_keywords` string (#302)
 

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -680,6 +680,11 @@ fn serialize_inner_xml(
                 Ok(Event::Text(e)) => {
                     let _ = writer.write_event(Event::Text(e));
                 }
+                Ok(Event::GeneralRef(e)) => {
+                    // quick-xml emits entity references (e.g. &amp;) as GeneralRef events;
+                    // pass them through so the writer re-emits them as &name;
+                    let _ = writer.write_event(Event::GeneralRef(e));
+                }
                 Ok(Event::CData(e)) => {
                     let _ = writer.write_event(Event::CData(e));
                 }
@@ -1056,6 +1061,29 @@ mod tests {
         assert!(result.contains("<li>A</li>"));
         assert!(result.contains("<li>B</li>"));
         assert!(!result.contains("<div"));
+        assert!(!had_bozo);
+    }
+
+    #[test]
+    fn test_read_xhtml_content_preserves_entities() {
+        let xml = b"<content type=\"xhtml\"><div xmlns=\"http://www.w3.org/1999/xhtml\"><p>Tom &amp; Jerry</p><p>x &lt; y &gt; z</p></div></content>";
+        let mut reader = Reader::from_reader(&xml[..]);
+        let mut buf = Vec::new();
+        advance_past_start_xhtml(&mut reader, &mut buf);
+        let (result, had_bozo) =
+            read_xhtml_content(&mut reader, &mut buf, &ParserLimits::default()).unwrap();
+        assert!(
+            result.contains("&amp;"),
+            "& must be preserved as &amp;, got: {result}"
+        );
+        assert!(
+            result.contains("&lt;"),
+            "< must be preserved as &lt;, got: {result}"
+        );
+        assert!(
+            result.contains("&gt;"),
+            "> must be preserved as &gt;, got: {result}"
+        );
         assert!(!had_bozo);
     }
 


### PR DESCRIPTION
## Summary

- `serialize_inner_xml` in `common.rs` was not handling `Event::GeneralRef` events emitted by quick-xml 0.39 for entity references (`&amp;`, `&lt;`, `&gt;`), causing them to be silently dropped from xhtml content output
- Added `Event::GeneralRef` arm that passes the event through to the Writer, which re-emits it as `&name;`
- Added regression test `test_read_xhtml_content_preserves_entities`

Fixes #215.

## Test plan

- [ ] `cargo nextest run` — 955/955 tests pass (including new regression test)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo deny check` — clean
- [ ] `cargo doc --no-deps` — clean
- [ ] Regression test verifies `&amp;`, `&lt;`, `&gt;` preserved in xhtml content value
- [ ] Valid feed does NOT trigger `bozo = true`