### PR TITLE
fix(core): itunes:category → feed.tags; Atom 0.3 tagline/copyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Core: `itunes:category` elements at channel/feed level are now mapped to `feed.tags` (term and label set to category text, scheme None), matching Python feedparser behavior (#204)
+- Core: Atom 0.3 `<tagline>` is now mapped to `feed.subtitle`/`feed.subtitle_detail` and `<copyright>` to `feed.rights`/`feed.rights_detail` (#203)
 - Core: RSS `<generator>` now populates `feed.generator_detail` with `name` set (matching Python feedparser behavior); previously only `feed.generator` was set (#254)
 - Core: `slash:hit_parade` is now parsed from RSS entries into `entry.slash_hit_parade`; also fixed `extract_ns_local_name` to allow underscores in namespace-local tag names (#244)
 - Core, Python, Node.js bindings: RSS 2.0 optional channel elements `<cloud>`, `<textInput>`, `<skipHours>`, `<skipDays>` are now parsed and exposed as `feed.cloud`, `feed.textinput`, `feed.skiphours`, `feed.skipdays` (#200)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -239,7 +239,7 @@ fn parse_feed_element(
                             skip_to_end(reader, &mut buf, b"link")?;
                         }
                     }
-                    b"subtitle" if !is_empty => {
+                    b"subtitle" | b"tagline" if !is_empty => {
                         let text =
                             parse_text_construct(reader, &mut buf, &element, limits, feed_lang)?;
                         feed.feed.set_subtitle(text);
@@ -303,7 +303,7 @@ fn parse_feed_element(
                         let url = read_text_str(reader, &mut buf, limits)?;
                         feed.feed.logo = Some(base_ctx.resolve_safe(&url));
                     }
-                    b"rights" if !is_empty => {
+                    b"rights" | b"copyright" if !is_empty => {
                         let text =
                             parse_text_construct(reader, &mut buf, &element, limits, feed_lang)?;
                         feed.feed.set_rights(text);
@@ -695,11 +695,11 @@ fn parse_entry(
                         entry.created = parse_date(&text);
                         entry.created_str = Some(text);
                     }
-                    b"subtitle" if !is_empty => {
+                    b"subtitle" | b"tagline" if !is_empty => {
                         let text = parse_text_construct(reader, buf, &element, limits, entry_lang)?;
                         entry.set_subtitle(text);
                     }
-                    b"rights" if !is_empty => {
+                    b"rights" | b"copyright" if !is_empty => {
                         let text = parse_text_construct(reader, buf, &element, limits, entry_lang)?;
                         entry.set_rights(text);
                     }
@@ -1648,6 +1648,24 @@ fn parse_atom_itunes_category(
         }
     }
 
+    feed.feed.tags.try_push_limited(
+        Tag {
+            term: text.as_str().into(),
+            scheme: None,
+            label: Some(text.as_str().into()),
+        },
+        limits.max_tags,
+    );
+    if let Some(ref sub) = subcategory {
+        feed.feed.tags.try_push_limited(
+            Tag {
+                term: sub.as_str().into(),
+                scheme: None,
+                label: Some(sub.as_str().into()),
+            },
+            limits.max_tags,
+        );
+    }
     let itunes = feed
         .feed
         .itunes
@@ -3212,6 +3230,59 @@ mod tests {
             feed.feed.subtitle.as_deref(),
             Some("Only iTunes subtitle"),
             "itunes:subtitle must set feed.subtitle when no native <subtitle> present"
+        );
+    }
+
+    #[test]
+    fn test_atom03_tagline_maps_to_subtitle() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://purl.org/atom/ns#" version="0.3">
+            <title>Test Feed</title>
+            <tagline>My tagline</tagline>
+            <modified>2004-01-01T00:00:00Z</modified>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.version, FeedVersion::Atom03);
+        assert_eq!(feed.feed.subtitle.as_deref(), Some("My tagline"));
+    }
+
+    #[test]
+    fn test_atom03_copyright_maps_to_rights() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://purl.org/atom/ns#" version="0.3">
+            <title>Test Feed</title>
+            <copyright>CC BY 4.0</copyright>
+            <modified>2004-01-01T00:00:00Z</modified>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.version, FeedVersion::Atom03);
+        assert_eq!(feed.feed.rights.as_deref(), Some("CC BY 4.0"));
+    }
+
+    #[test]
+    fn test_atom_itunes_category_maps_to_tags() {
+        let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom"
+              xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <title>Podcast Feed</title>
+            <itunes:category text="Technology">
+                <itunes:category text="Software How-To"/>
+            </itunes:category>
+        </feed>"#;
+        let feed = parse_atom10(xml).unwrap();
+        assert!(
+            feed.feed.tags.iter().any(|t| t.term == "Technology"),
+            "Technology category must appear in tags"
+        );
+        assert!(
+            feed.feed.tags.iter().any(|t| t.term == "Software How-To"),
+            "Software How-To subcategory must appear in tags"
+        );
+        let itunes = feed.feed.itunes.as_ref().unwrap();
+        assert_eq!(itunes.categories[0].text, "Technology");
+        assert_eq!(
+            itunes.categories[0].subcategory.as_deref(),
+            Some("Software How-To")
         );
     }
 }

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -824,7 +824,7 @@ fn parse_itunes_category(
         .unwrap_or_default();
 
     // Parse potential nested subcategory (only if not an empty element)
-    let mut subcategory_text = None;
+    let mut subcategory_text: Option<String> = None;
     if !is_empty {
         let mut nesting = 0;
         loop {
@@ -876,6 +876,24 @@ fn parse_itunes_category(
         }
     }
 
+    feed.feed.tags.try_push_limited(
+        Tag {
+            term: category_text.as_str().into(),
+            scheme: None,
+            label: Some(category_text.as_str().into()),
+        },
+        limits.max_tags,
+    );
+    if let Some(ref sub) = subcategory_text {
+        feed.feed.tags.try_push_limited(
+            Tag {
+                term: sub.as_str().into(),
+                scheme: None,
+                label: Some(sub.as_str().into()),
+            },
+            limits.max_tags,
+        );
+    }
     let itunes = feed
         .feed
         .itunes
@@ -4978,6 +4996,36 @@ mod tests {
         assert_eq!(
             feed.feed.podcast.as_ref().unwrap().medium.as_deref(),
             Some("music")
+        );
+    }
+
+    #[test]
+    fn test_rss_itunes_category_maps_to_tags() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <title>Podcast</title>
+                <link>http://example.com</link>
+                <description>A podcast</description>
+                <itunes:category text="Technology">
+                    <itunes:category text="Software How-To"/>
+                </itunes:category>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert!(
+            feed.feed.tags.iter().any(|t| t.term == "Technology"),
+            "Technology category must appear in tags"
+        );
+        assert!(
+            feed.feed.tags.iter().any(|t| t.term == "Software How-To"),
+            "Software How-To subcategory must appear in tags"
+        );
+        let itunes = feed.feed.itunes.as_ref().unwrap();
+        assert_eq!(itunes.categories[0].text, "Technology");
+        assert_eq!(
+            itunes.categories[0].subcategory.as_deref(),
+            Some("Software How-To")
         );
     }
 }


### PR DESCRIPTION
## Summary

- Maps `itunes:category` elements at channel/feed level to `feed.tags` (term and label = category text, scheme = None), matching Python feedparser behavior — fixes #204
- Maps Atom 0.3 `<tagline>` to `feed.subtitle`/`feed.subtitle_detail` and `<copyright>` to `feed.rights`/`feed.rights_detail` at feed and entry level — fixes #203

## Changes

- `crates/feedparser-rs-core/src/parser/rss.rs`: `parse_itunes_category()` now pushes category and subcategory (if present) to `feed.feed.tags`
- `crates/feedparser-rs-core/src/parser/atom.rs`: `parse_atom_itunes_category()` same; `parse_feed_element()` and `parse_entry()` now match `b"tagline"` alongside `b"subtitle"` and `b"copyright"` alongside `b"rights"`

## Test plan

- [ ] `test_rss_itunes_category_maps_to_tags` — RSS channel with itunes:category and subcategory
- [ ] `test_atom_itunes_category_maps_to_tags` — Atom feed with itunes:category
- [ ] `test_atom03_tagline_maps_to_subtitle` — Atom 0.3 feed with tagline
- [ ] `test_atom03_copyright_maps_to_rights` — Atom 0.3 feed with copyright
- [ ] 982 tests passed, clippy clean, fmt clean

## Bozo gate

Valid feeds do not trigger `bozo = true`. No parsing paths were changed in ways that affect error handling.