### PR TITLE
fix(core): iTunes owner email in feed.author; xhtml &apos;/&quot; decoded (#317, #316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: `podcast:person` default role changed from `"unknown"` to `"host"` per Podcast 2.0 spec; Python binding now returns `"host"` instead of `None` when no `role` attribute is present (#236)
 - Core: `itunes:summary`-only no longer incorrectly sets `feed.subtitle`; only `itunes:subtitle` promotes to `feed.subtitle` (#308)
 - Core: `feed.author` now uses `itunes:owner.name` (with email in `author_detail`) when both `itunes:owner` and `itunes:author` are present, matching Python feedparser priority (#297)
+- Core: `feed.author` from `itunes:owner` now contains name only (no `"Name (email)"` format); `feed.author_detail` still carries both name and email (#317)
+- Core: `&apos;` and `&quot;` entity references inside xhtml content now decode to literal `'` and `"` characters instead of passing through as escaped entity refs (#316)
 - Core: `itunes:image` now overrides RSS `<image>` for `feed.image` regardless of element order, matching Python feedparser behavior (#287)
 - Core, Python, Node.js bindings: `MediaContent.filesize` is now a `String` (was `u64`/`i64`), matching Python feedparser which preserves raw attribute values; non-numeric values like `"not_a_number"` are now retained as-is (#221)
 - Core, Python, Node.js bindings: `media:credit`, `media:copyright`, `media:rating`, `media:keywords`, and `media:description` are now parsed from RSS and Atom feeds and exposed on `Entry` as `media_credit`, `media_copyright`, `media_rating`, `media_keywords`, and `media_description` (#246, #288)

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -686,13 +686,23 @@ fn serialize_inner_xml(
                     let _ = writer.write_event(Event::Text(e));
                 }
                 Ok(Event::GeneralRef(e)) => {
-                    // Entity references (e.g. &amp;, &lt;) are emitted as separate
-                    // GeneralRef events by quick-xml. Re-emit them verbatim so that
-                    // &amp; → &amp; (not lost) in the serialized XHTML output.
+                    // #316: &apos; and &quot; must decode to literal characters.
+                    // &amp;, &lt;, &gt; must remain escaped in HTML output.
+                    // All other entity refs are re-emitted verbatim.
                     let inner = writer.get_mut();
-                    let _ = inner.write_all(b"&");
-                    let _ = inner.write_all(e.as_ref());
-                    let _ = inner.write_all(b";");
+                    match e.as_ref() {
+                        b"apos" => {
+                            let _ = inner.write_all(b"'");
+                        }
+                        b"quot" => {
+                            let _ = inner.write_all(b"\"");
+                        }
+                        _ => {
+                            let _ = inner.write_all(b"&");
+                            let _ = inner.write_all(e.as_ref());
+                            let _ = inner.write_all(b";");
+                        }
+                    }
                 }
                 Ok(Event::CData(e)) => {
                     let _ = writer.write_event(Event::CData(e));
@@ -1094,6 +1104,34 @@ mod tests {
         assert!(
             !result.contains("Tom & Jerry"),
             "bare & must not appear in output, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_read_xhtml_content_apos_and_quot_decoded() {
+        // #316: &apos; must become ' and &quot; must become " in xhtml output
+        let xml = b"<content type=\"xhtml\"><div xmlns=\"http://www.w3.org/1999/xhtml\"><p>it&apos;s a &quot;test&quot;</p></div></content>";
+        let mut reader = Reader::from_reader(&xml[..]);
+        let mut buf = Vec::new();
+        advance_past_start_xhtml(&mut reader, &mut buf);
+        let (result, had_bozo) =
+            read_xhtml_content(&mut reader, &mut buf, &ParserLimits::default()).unwrap();
+        assert!(!had_bozo);
+        assert!(
+            result.contains("it's a"),
+            "&apos; must decode to literal apostrophe, got: {result}"
+        );
+        assert!(
+            result.contains("\"test\""),
+            "&quot; must decode to literal quote, got: {result}"
+        );
+        assert!(
+            !result.contains("&apos;"),
+            "&apos; must not remain escaped in output, got: {result}"
+        );
+        assert!(
+            !result.contains("&quot;"),
+            "&quot; must not remain escaped in output, got: {result}"
         );
     }
 

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -219,7 +219,10 @@ fn apply_itunes_feed_promotions(feed: &mut FeedMeta) {
                 email: owner_email.as_deref().map(crate::types::Email::new),
                 uri: None,
             };
-            feed.set_author(person.clone());
+            // #317: feed.author must be name-only (no email in parentheses).
+            // author_detail still carries the full person (name + email).
+            feed.author.clone_from(&person.name);
+            feed.author_detail = Some(person.clone());
             feed.authors.try_push_limited(person, usize::MAX);
         } else if let Some(ref name) = itunes_author
             && !name.trim().is_empty()
@@ -4263,10 +4266,10 @@ mod tests {
             </channel>
         </rss>"#;
         let feed = parse_rss20(xml).unwrap();
-        // flat author string follows "Name (email)" convention
+        // #317: feed.author must be name-only, no email in parentheses
         assert_eq!(
             feed.feed.author.as_deref(),
-            Some("Owner Name (owner@example.com)"),
+            Some("Owner Name"),
             "itunes:owner.name must win over itunes:author"
         );
         let detail = feed.feed.author_detail.as_ref().unwrap();
@@ -4289,11 +4292,36 @@ mod tests {
             </channel>
         </rss>"#;
         let feed = parse_rss20(xml).unwrap();
+        // #317: feed.author must be name-only
         assert_eq!(
             feed.feed.author.as_deref(),
-            Some("Owner Name (owner@example.com)"),
+            Some("Owner Name"),
             "itunes:owner.name must win regardless of element order"
         );
+    }
+
+    // #317: itunes:owner with name+email — feed.author is name only, author_detail has both
+    #[test]
+    fn test_itunes_owner_author_name_only_no_email() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+            <channel>
+                <title>Podcast</title>
+                <itunes:owner>
+                    <itunes:name>Jane Doe</itunes:name>
+                    <itunes:email>jane@example.com</itunes:email>
+                </itunes:owner>
+            </channel>
+        </rss>"#;
+        let feed = parse_rss20(xml).unwrap();
+        assert_eq!(
+            feed.feed.author.as_deref(),
+            Some("Jane Doe"),
+            "feed.author must be name only — no email in parentheses"
+        );
+        let detail = feed.feed.author_detail.as_ref().unwrap();
+        assert_eq!(detail.name.as_deref(), Some("Jane Doe"));
+        assert_eq!(detail.email.as_deref(), Some("jane@example.com"));
     }
 
     // #287: itunes:image must override RSS <image>


### PR DESCRIPTION
## Summary

- **#317**: `feed.author` from `itunes:owner` now contains name only; previously included `" (email@example.com)"` suffix when owner had both name and email. `feed.author_detail` still carries both name and email fields.
- **#316**: `&apos;` and `&quot;` entity references in xhtml content now decode to literal `'` and `"` characters. quick-xml emits these as `Event::GeneralRef` which was previously unhandled in `serialize_inner_xml`.

## Changes

- `crates/feedparser-rs-core/src/parser/rss.rs`: `apply_itunes_feed_promotions` — set `feed.author` to name only via `clone_from`, keeping full person in `author_detail`
- `crates/feedparser-rs-core/src/parser/common.rs`: `serialize_inner_xml` — added `b"apos"` and `b"quot"` arms in `GeneralRef` handler

## Test plan

- Added `test_itunes_owner_author_name_only_no_email` — verifies `feed.author` is name-only and `author_detail` has both fields
- Added `test_read_xhtml_content_apos_and_quot_decoded` — verifies literal `'` and `"` in xhtml output
- 985 tests pass
- `cargo clippy` clean, `cargo +nightly fmt` clean

## Bozo gate

- Valid feeds do not trigger `bozo = true`
- Changes are in promotion logic and serialization, not XML parsing path

Closes #317
Closes #316