### PR TITLE
fix(core): PodcastEntryMeta.persons rename, medium field; podcast:locked (#320, #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: `PodcastEntryMeta.person` renamed to `PodcastEntryMeta.persons` for consistency with feed-level `PodcastMeta.persons` (#320)
 - **BREAKING**: `ItunesFeedMeta.complete` changed from `Option<bool>` to `Option<String>` to return the raw XML text value (e.g. `"Yes"`, `"No"`) instead of a parsed boolean (#281)
 - `itunes:subtitle` now always overrides `<description>` for `feed.subtitle` regardless of XML element order; previously it only set subtitle when absent (#257)
 - `itunes:summary` populates new `feed.summary` field instead of aliasing to `feed.subtitle` (#257)
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Core, Python, Node.js bindings: `PodcastEntryMeta.medium` field exposes `podcast:medium` at entry/item level (#320)
+- Core, Python, Node.js bindings: `PodcastMeta.locked` and `PodcastMeta.locked_owner` fields parse `podcast:locked` feed-level element (Podcast 2.0 spec) (#213)
 - Core, Python, Node.js bindings: `PodcastMeta.medium` field exposes `podcast:medium` feed-level element (Podcast 2.0 spec: content type string such as `podcast`, `music`, `video`, etc.) (#255)
 - Core: `podcast:person` elements at feed/channel level are now collected into `feed.podcast.persons`; previously only entry-level persons were parsed (#292)
 - Core, Python, Node.js bindings: `FeedMeta.summary` and `FeedMeta.summary_detail` fields populated from `itunes:summary` (#257)

--- a/crates/feedparser-rs-core/examples/podcast_feed.rs
+++ b/crates/feedparser-rs-core/examples/podcast_feed.rs
@@ -256,9 +256,9 @@ fn display_episodes(feed: &feedparser_rs::ParsedFeed) {
             }
 
             // Guest information
-            if !podcast.person.is_empty() {
+            if !podcast.persons.is_empty() {
                 println!("    People:");
-                for person in &podcast.person {
+                for person in &podcast.persons {
                     print!("      - {}", person.name);
                     if let Some(role) = &person.role {
                         print!(" ({role})");

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1004,6 +1004,25 @@ fn parse_channel_podcast(
             }
         }
         Ok(true)
+    } else if tag.starts_with(b"podcast:locked") {
+        if !is_empty {
+            let owner = attrs
+                .iter()
+                .find(|(k, _)| k == b"owner")
+                .map(|(_, v)| v.clone());
+            let text = read_text_str(reader, buf, limits)?;
+            let podcast = feed
+                .feed
+                .podcast
+                .get_or_insert_with(|| Box::new(PodcastMeta::default()));
+            if !text.is_empty() {
+                podcast.locked = Some(text);
+            }
+            if let Some(o) = owner.filter(|o| !o.is_empty()) {
+                podcast.locked_owner = Some(o);
+            }
+        }
+        Ok(true)
     } else {
         Ok(false)
     }
@@ -1568,6 +1587,17 @@ fn parse_item_podcast(
     } else if tag.starts_with(b"podcast:soundbite") {
         parse_podcast_soundbite(reader, buf, attrs, entry, limits, is_empty, depth)?;
         Ok(true)
+    } else if tag.starts_with(b"podcast:medium") {
+        if !is_empty {
+            let text = read_text_str(reader, buf, limits)?;
+            if !text.is_empty() {
+                let podcast = entry
+                    .podcast
+                    .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()));
+                podcast.medium = Some(text);
+            }
+        }
+        Ok(true)
     } else {
         Ok(false)
     }
@@ -1656,7 +1686,7 @@ fn parse_podcast_person(
             .podcast
             .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()));
         podcast
-            .person
+            .persons
             .try_push_limited(person, limits.max_podcast_persons);
     }
 
@@ -3535,19 +3565,19 @@ mod tests {
             .podcast
             .as_deref()
             .expect("entry.podcast should be Some");
-        assert_eq!(podcast.person.len(), 2);
-        assert_eq!(podcast.person[0].name, "Jane Doe");
-        assert_eq!(podcast.person[0].role.as_deref(), Some("host"));
+        assert_eq!(podcast.persons.len(), 2);
+        assert_eq!(podcast.persons[0].name, "Jane Doe");
+        assert_eq!(podcast.persons[0].role.as_deref(), Some("host"));
         assert_eq!(
-            podcast.person[0].href.as_deref(),
+            podcast.persons[0].href.as_deref(),
             Some("https://example.com/host")
         );
         assert_eq!(
-            podcast.person[0].img.as_deref(),
+            podcast.persons[0].img.as_deref(),
             Some("https://example.com/host.jpg")
         );
-        assert_eq!(podcast.person[1].name, "John Smith");
-        assert_eq!(podcast.person[1].role.as_deref(), Some("guest"));
+        assert_eq!(podcast.persons[1].name, "John Smith");
+        assert_eq!(podcast.persons[1].role.as_deref(), Some("guest"));
     }
 
     #[test]
@@ -3571,7 +3601,7 @@ mod tests {
             .as_deref()
             .expect("entry.podcast must be Some when only transcript/person present");
         assert_eq!(podcast.transcript.len(), 1);
-        assert_eq!(podcast.person.len(), 1);
+        assert_eq!(podcast.persons.len(), 1);
         assert!(podcast.chapters.is_none());
         assert!(podcast.soundbite.is_empty());
     }
@@ -5055,5 +5085,58 @@ mod tests {
             itunes.categories[0].subcategory.as_deref(),
             Some("Software How-To")
         );
+    }
+
+    #[test]
+    fn test_parse_rss_podcast_medium_entry_level() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <channel>
+                <title>Test Podcast</title>
+                <item>
+                    <title>Episode 1</title>
+                    <podcast:medium>music</podcast:medium>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo);
+        let podcast = feed.entries[0].podcast.as_deref().unwrap();
+        assert_eq!(podcast.medium.as_deref(), Some("music"));
+    }
+
+    #[test]
+    fn test_parse_rss_podcast_locked() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <channel>
+                <title>Test Podcast</title>
+                <podcast:locked owner="owner@example.com">yes</podcast:locked>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo);
+        let podcast = feed.feed.podcast.as_ref().unwrap();
+        assert_eq!(podcast.locked.as_deref(), Some("yes"));
+        assert_eq!(podcast.locked_owner.as_deref(), Some("owner@example.com"));
+    }
+
+    #[test]
+    fn test_parse_rss_podcast_locked_no_owner() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <channel>
+                <title>Test Podcast</title>
+                <podcast:locked>no</podcast:locked>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo);
+        let podcast = feed.feed.podcast.as_ref().unwrap();
+        assert_eq!(podcast.locked.as_deref(), Some("no"));
+        assert!(podcast.locked_owner.is_none());
     }
 }

--- a/crates/feedparser-rs-core/src/types/podcast.rs
+++ b/crates/feedparser-rs-core/src/types/podcast.rs
@@ -175,6 +175,10 @@ pub struct PodcastMeta {
     pub value: Option<PodcastValue>,
     /// Content medium type (podcast:medium)
     pub medium: Option<String>,
+    /// Ownership transfer lock (podcast:locked text content: "yes" or "no")
+    pub locked: Option<String>,
+    /// Email of the lock owner (podcast:locked owner attribute)
+    pub locked_owner: Option<String>,
 }
 
 /// Podcast 2.0 value element for monetization
@@ -467,7 +471,9 @@ pub struct PodcastEntryMeta {
     /// Shareable soundbites (podcast:soundbite)
     pub soundbite: Vec<PodcastSoundbite>,
     /// People associated with this episode (podcast:person)
-    pub person: Vec<PodcastPerson>,
+    pub persons: Vec<PodcastPerson>,
+    /// Content medium type (podcast:medium)
+    pub medium: Option<String>,
 }
 
 /// Parse iTunes explicit flag from various string representations
@@ -706,7 +712,8 @@ mod tests {
         assert!(meta.transcript.is_empty());
         assert!(meta.chapters.is_none());
         assert!(meta.soundbite.is_empty());
-        assert!(meta.person.is_empty());
+        assert!(meta.persons.is_empty());
+        assert!(meta.medium.is_none());
     }
 
     #[test]

--- a/crates/feedparser-rs-core/tests/test_podcast_namespace.rs
+++ b/crates/feedparser-rs-core/tests/test_podcast_namespace.rs
@@ -247,7 +247,7 @@ fn test_podcast_entry_meta_default() {
     assert!(meta.transcript.is_empty());
     assert!(meta.chapters.is_none());
     assert!(meta.soundbite.is_empty());
-    assert!(meta.person.is_empty());
+    assert!(meta.persons.is_empty());
 }
 
 #[test]

--- a/crates/feedparser-rs-node/index.d.ts
+++ b/crates/feedparser-rs-node/index.d.ts
@@ -584,7 +584,9 @@ export interface PodcastEntryMeta {
   /** Episode soundbites */
   soundbite: Array<PodcastSoundbite>
   /** Episode persons */
-  person: Array<PodcastPerson>
+  persons: Array<PodcastPerson>
+  /** Content medium type (podcast:medium) */
+  medium?: string
 }
 
 /** Podcast funding link */
@@ -611,6 +613,12 @@ export interface PodcastMeta {
   guid?: string
   /** Value-for-value payment information */
   value?: PodcastValue
+  /** Content medium type (podcast:medium) */
+  medium?: string
+  /** Ownership transfer lock value: "yes" or "no" (podcast:locked) */
+  locked?: string
+  /** Email of the lock owner (podcast:locked owner attribute) */
+  lockedOwner?: string
 }
 
 /** Podcast person metadata */

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -1396,6 +1396,10 @@ pub struct PodcastMeta {
     pub value: Option<PodcastValue>,
     /// Content medium type (podcast:medium)
     pub medium: Option<String>,
+    /// Ownership transfer lock value: "yes" or "no" (podcast:locked)
+    pub locked: Option<String>,
+    /// Email of the lock owner (podcast:locked owner attribute)
+    pub locked_owner: Option<String>,
 }
 
 impl From<CorePodcastMeta> for PodcastMeta {
@@ -1411,6 +1415,8 @@ impl From<CorePodcastMeta> for PodcastMeta {
             guid: core.guid,
             value: core.value.map(PodcastValue::from),
             medium: core.medium,
+            locked: core.locked,
+            locked_owner: core.locked_owner,
         }
     }
 }
@@ -1502,7 +1508,9 @@ pub struct PodcastEntryMeta {
     /// Episode soundbites
     pub soundbite: Vec<PodcastSoundbite>,
     /// Episode persons
-    pub person: Vec<PodcastPerson>,
+    pub persons: Vec<PodcastPerson>,
+    /// Content medium type (podcast:medium)
+    pub medium: Option<String>,
 }
 
 impl From<CorePodcastEntryMeta> for PodcastEntryMeta {
@@ -1519,7 +1527,8 @@ impl From<CorePodcastEntryMeta> for PodcastEntryMeta {
                 .into_iter()
                 .map(PodcastSoundbite::from)
                 .collect(),
-            person: core.person.into_iter().map(PodcastPerson::from).collect(),
+            persons: core.persons.into_iter().map(PodcastPerson::from).collect(),
+            medium: core.medium,
         }
     }
 }

--- a/crates/feedparser-rs-py/src/types/podcast.rs
+++ b/crates/feedparser-rs-py/src/types/podcast.rs
@@ -450,6 +450,16 @@ impl PyPodcastMeta {
         self.inner.medium.as_deref()
     }
 
+    #[getter]
+    fn locked(&self) -> Option<&str> {
+        self.inner.locked.as_deref()
+    }
+
+    #[getter]
+    fn locked_owner(&self) -> Option<&str> {
+        self.inner.locked_owner.as_deref()
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "PodcastMeta(guid='{}', persons={}, medium='{}')",
@@ -741,12 +751,17 @@ impl PyPodcastEntryMeta {
     }
 
     #[getter]
-    fn person(&self) -> Vec<PyPodcastPerson> {
+    fn persons(&self) -> Vec<PyPodcastPerson> {
         self.inner
-            .person
+            .persons
             .iter()
             .map(|p| PyPodcastPerson::from_core(p.clone()))
             .collect()
+    }
+
+    #[getter]
+    fn medium(&self) -> Option<&str> {
+        self.inner.medium.as_deref()
     }
 
     fn __repr__(&self) -> String {
@@ -759,7 +774,7 @@ impl PyPodcastEntryMeta {
                 "none"
             },
             self.inner.soundbite.len(),
-            self.inner.person.len()
+            self.inner.persons.len()
         )
     }
 }


### PR DESCRIPTION
## Summary

- **#320**: Rename `PodcastEntryMeta.person` → `PodcastEntryMeta.persons` for consistency with feed-level `PodcastMeta.persons`
- **#320**: Add `PodcastEntryMeta.medium` field exposing `podcast:medium` at entry/item level
- **#213**: Add `PodcastMeta.locked` and `PodcastMeta.locked_owner` fields parsing `<podcast:locked owner="...">yes</podcast:locked>` at feed level

All changes reflected in core types, Python bindings, Node.js bindings, and TypeScript definitions.

## Breaking changes

- `PodcastEntryMeta.person` renamed to `PodcastEntryMeta.persons` (core, Python, Node.js)

## Test plan

- [ ] `cargo nextest run` — 999 tests pass
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [ ] `cargo +nightly fmt --check` — clean
- [ ] New tests: `test_parse_rss_podcast_medium_entry_level`, `test_parse_rss_podcast_locked`, `test_parse_rss_podcast_locked_no_owner`
- [ ] Bozo gate: valid feeds do not set `bozo = true`; tested with both valid and malformed inputs