### PR TITLE
fix(core): itunes:category tags scheme/label wrong values (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Core: `itunes:category` tags now have `scheme='http://www.itunes.com/'` and `label=None`, matching Python feedparser; previously `scheme` was `None` and `label` was a copy of `term` (#325)
 - Core: `itunes:category` elements at channel/feed level are now mapped to `feed.tags` (term and label set to category text, scheme None), matching Python feedparser behavior (#204)
 - Core: Atom 0.3 `<tagline>` is now mapped to `feed.subtitle`/`feed.subtitle_detail` and `<copyright>` to `feed.rights`/`feed.rights_detail` (#203)
 - Core: RSS `<generator>` now populates `feed.generator_detail` with `name` set (matching Python feedparser behavior); previously only `feed.generator` was set (#254)

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -1651,8 +1651,8 @@ fn parse_atom_itunes_category(
     feed.feed.tags.try_push_limited(
         Tag {
             term: text.as_str().into(),
-            scheme: None,
-            label: Some(text.as_str().into()),
+            scheme: Some("http://www.itunes.com/".into()),
+            label: None,
         },
         limits.max_tags,
     );
@@ -1660,8 +1660,8 @@ fn parse_atom_itunes_category(
         feed.feed.tags.try_push_limited(
             Tag {
                 term: sub.as_str().into(),
-                scheme: None,
-                label: Some(sub.as_str().into()),
+                scheme: Some("http://www.itunes.com/".into()),
+                label: None,
             },
             limits.max_tags,
         );
@@ -3270,14 +3270,29 @@ mod tests {
             </itunes:category>
         </feed>"#;
         let feed = parse_atom10(xml).unwrap();
-        assert!(
-            feed.feed.tags.iter().any(|t| t.term == "Technology"),
-            "Technology category must appear in tags"
+        let tech_tag = feed
+            .feed
+            .tags
+            .iter()
+            .find(|t| t.term == "Technology")
+            .expect("Technology category must appear in tags");
+        assert_eq!(
+            tech_tag.scheme.as_deref(),
+            Some("http://www.itunes.com/"),
+            "itunes:category scheme must be http://www.itunes.com/"
         );
         assert!(
-            feed.feed.tags.iter().any(|t| t.term == "Software How-To"),
-            "Software How-To subcategory must appear in tags"
+            tech_tag.label.is_none(),
+            "itunes:category label must be None"
         );
+        let sub_tag = feed
+            .feed
+            .tags
+            .iter()
+            .find(|t| t.term == "Software How-To")
+            .expect("Software How-To subcategory must appear in tags");
+        assert_eq!(sub_tag.scheme.as_deref(), Some("http://www.itunes.com/"));
+        assert!(sub_tag.label.is_none());
         let itunes = feed.feed.itunes.as_ref().unwrap();
         assert_eq!(itunes.categories[0].text, "Technology");
         assert_eq!(

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -882,8 +882,8 @@ fn parse_itunes_category(
     feed.feed.tags.try_push_limited(
         Tag {
             term: category_text.as_str().into(),
-            scheme: None,
-            label: Some(category_text.as_str().into()),
+            scheme: Some("http://www.itunes.com/".into()),
+            label: None,
         },
         limits.max_tags,
     );
@@ -891,8 +891,8 @@ fn parse_itunes_category(
         feed.feed.tags.try_push_limited(
             Tag {
                 term: sub.as_str().into(),
-                scheme: None,
-                label: Some(sub.as_str().into()),
+                scheme: Some("http://www.itunes.com/".into()),
+                label: None,
             },
             limits.max_tags,
         );
@@ -5071,14 +5071,29 @@ mod tests {
             </channel>
         </rss>"#;
         let feed = parse_rss20(xml).unwrap();
-        assert!(
-            feed.feed.tags.iter().any(|t| t.term == "Technology"),
-            "Technology category must appear in tags"
+        let tech_tag = feed
+            .feed
+            .tags
+            .iter()
+            .find(|t| t.term == "Technology")
+            .expect("Technology category must appear in tags");
+        assert_eq!(
+            tech_tag.scheme.as_deref(),
+            Some("http://www.itunes.com/"),
+            "itunes:category scheme must be http://www.itunes.com/"
         );
         assert!(
-            feed.feed.tags.iter().any(|t| t.term == "Software How-To"),
-            "Software How-To subcategory must appear in tags"
+            tech_tag.label.is_none(),
+            "itunes:category label must be None"
         );
+        let sub_tag = feed
+            .feed
+            .tags
+            .iter()
+            .find(|t| t.term == "Software How-To")
+            .expect("Software How-To subcategory must appear in tags");
+        assert_eq!(sub_tag.scheme.as_deref(), Some("http://www.itunes.com/"));
+        assert!(sub_tag.label.is_none());
         let itunes = feed.feed.itunes.as_ref().unwrap();
         assert_eq!(itunes.categories[0].text, "Technology");
         assert_eq!(


### PR DESCRIPTION
## Summary

- `itunes:category` `Tag` entries in `feed.tags` now have `scheme = 'http://www.itunes.com/'` and `label = None`, matching Python feedparser behavior
- Previously `scheme` was `None` and `label` duplicated the `term` value
- Fix applied to both RSS and Atom parsers

## Root cause

In `parse_itunes_category` (rss.rs) and the equivalent function in atom.rs, `Tag` structs were constructed with `scheme: None` and `label: Some(text)`. The correct values per Python feedparser are `scheme: Some("http://www.itunes.com/")` and `label: None`.

## Test plan

- [x] Existing tests `test_rss_itunes_category_maps_to_tags` and `test_atom_itunes_category_maps_to_tags` updated to assert correct `scheme`/`label` values
- [x] `cargo nextest run` — 1005 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo deny check` — clean

Closes #325