### PR TITLE
fix(core): JSON Feed icon/favicon field mapping (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core, Python, Node.js bindings: RSS 2.0 optional channel elements `<cloud>`, `<textInput>`, `<skipHours>`, `<skipDays>` are now parsed and exposed as `feed.cloud`, `feed.textinput`, `feed.skiphours`, `feed.skipdays` (#200)
 - Core: `podcast:person` default role changed from `"unknown"` to `"host"` per Podcast 2.0 spec; Python binding now returns `"host"` instead of `None` when no `role` attribute is present (#236)
 - Core: `itunes:summary`-only no longer incorrectly sets `feed.subtitle`; only `itunes:subtitle` promotes to `feed.subtitle` (#308)
+- Core: JSON Feed `icon` field now correctly maps to `feed.icon`; `favicon` field now correctly maps to `feed.logo` (previously `icon` was mapped to `feed.image` and `favicon` to `feed.icon`) (#329)
 - Core: `feed.author` now uses `itunes:owner.name` (with email in `author_detail`) when both `itunes:owner` and `itunes:author` are present, matching Python feedparser priority (#297)
 - Core: `feed.author` from `itunes:owner` now contains name only (no `"Name (email)"` format); `feed.author_detail` still carries both name and email (#317)
 - Core: `&apos;` and `&quot;` entity references inside xhtml content now decode to literal `'` and `"` characters instead of passing through as escaped entity refs (#316)

--- a/crates/feedparser-rs-core/src/parser/json.rs
+++ b/crates/feedparser-rs-core/src/parser/json.rs
@@ -6,8 +6,8 @@ use crate::{
     ParserLimits,
     error::{FeedError, Result},
     types::{
-        Content, Enclosure, Entry, FeedMeta, FeedVersion, Image, LimitedCollectionExt, Link,
-        ParseFrom, ParsedFeed, Person, Tag, TextConstruct,
+        Content, Enclosure, Entry, FeedMeta, FeedVersion, LimitedCollectionExt, Link, ParseFrom,
+        ParsedFeed, Person, Tag, TextConstruct,
     },
     util::{date::parse_date, text::truncate_to_length},
 };
@@ -108,20 +108,13 @@ fn parse_feed_metadata(json: &Value, feed: &mut FeedMeta, limits: &ParserLimits)
     if let Some(icon) = json.get("icon").and_then(|v| v.as_str())
         && icon.len() <= limits.max_text_length
     {
-        feed.image = Some(Image {
-            url: icon.to_string().into(),
-            title: None,
-            link: None,
-            width: None,
-            height: None,
-            description: None,
-        });
+        feed.icon = Some(icon.to_string());
     }
 
     if let Some(favicon) = json.get("favicon").and_then(|v| v.as_str())
         && favicon.len() <= limits.max_text_length
     {
-        feed.icon = Some(favicon.to_string());
+        feed.logo = Some(favicon.to_string());
     }
 
     parse_authors(
@@ -397,14 +390,14 @@ mod tests {
         assert_eq!(feed.feed.title.as_deref(), Some("Example Feed"));
         assert_eq!(feed.feed.link.as_deref(), Some("https://example.com"));
         assert_eq!(feed.feed.subtitle.as_deref(), Some("Feed description"));
-        // icon → feed.image (large timeline image per JSON Feed spec)
-        assert_eq!(
-            feed.feed.image.as_ref().map(|i| i.url.as_str()),
-            Some("https://example.com/icon.png")
-        );
-        // favicon → feed.icon (small browser favicon per JSON Feed spec)
+        // icon (512x512 app icon) → feed.icon
         assert_eq!(
             feed.feed.icon.as_deref(),
+            Some("https://example.com/icon.png")
+        );
+        // favicon (small browser icon) → feed.logo
+        assert_eq!(
+            feed.feed.logo.as_deref(),
             Some("https://example.com/favicon.ico")
         );
         assert_eq!(feed.feed.language.as_deref(), Some("en-US"));


### PR DESCRIPTION
## Summary

- `icon` field now correctly maps to `feed.icon` (was incorrectly mapped to `feed.image`)
- `favicon` field now correctly maps to `feed.logo` (was incorrectly mapped to `feed.icon`)
- Removed unused `Image` import from `json.rs`

## Root cause

PR #326 introduced the wrong mapping: `icon` was stored as `feed.image` (an `Image` struct) and `favicon` was stored as `feed.icon`. The correct mapping per JSON Feed spec is `icon` (large 512x512 app icon) → `feed.icon` and `favicon` (small browser icon) → `feed.logo`.

## Bozo pattern gate

- Valid JSON Feed with `icon` and `favicon` fields: `bozo = false`, fields correctly populated
- Malformed JSON: `bozo = true`, parsing continues without panic

## Test plan

- Updated existing `test_parse_json_feed_basic` to assert correct mappings
- All 1009 tests pass
- `cargo clippy --all-targets --all-features -- -D warnings`: clean

Closes #329