### PR TITLE
docs(changelog): document skiphours/skipdays/textinput behavior vs Python feedparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `feed.skiphours` returns `Vec<u32>` with correctly parsed hour values and `feed.skipdays` returns `Vec<String>` with day names, versus Python feedparser which incorrectly returns empty strings for both fields. `feed.textinput` returns a populated `TextInput` struct with all child fields, versus Python feedparser which returns an empty dict. This is an intentional improvement over Python feedparser's behavior (#336).
+
 ## [0.5.1] - 2026-03-24
 
 ### Changed


### PR DESCRIPTION
## Summary

- Documents that `feed.skiphours`, `feed.skipdays`, and `feed.textinput` return correctly parsed values in feedparser-rs, unlike Python feedparser which incorrectly returns empty strings/dicts for these fields
- This is an intentional improvement, not a bug

## Changes

- `CHANGELOG.md`: added entry under `[Unreleased]` → `### Changed` explaining the behavioral difference

## Tests

Existing tests in `crates/feedparser-rs-core/tests/test_rss_optional_elements.rs` already cover all three fields (7 tests). All 1017 tests pass.

Closes #336