### PR TITLE
feat(core): parse podcast:season/episode and expose podcast:value in bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Core, Python, Node.js bindings: `PodcastEntryMeta.season` and `PodcastEntryMeta.episode` fields parse `podcast:season` and `podcast:episode` elements via the `number` attribute (Podcast 2.0 spec) (#332)
+- Python binding: `PyPodcastValue` and `PyPodcastValueRecipient` classes expose existing `podcast:value` data to Python; `PodcastMeta.value` getter added to `PyPodcastMeta` (#337)
+
 ### Changed
 
 - `feed.skiphours` returns `Vec<u32>` with correctly parsed hour values and `feed.skipdays` returns `Vec<String>` with day names, versus Python feedparser which incorrectly returns empty strings for both fields. `feed.textinput` returns a populated `TextInput` struct with all child fields, versus Python feedparser which returns an empty dict. This is an intentional improvement over Python feedparser's behavior (#336).

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1604,6 +1604,28 @@ fn parse_item_podcast(
             }
         }
         Ok(true)
+    } else if tag.starts_with(b"podcast:season") {
+        if let Some(number) = find_attribute(attrs, b"number") {
+            let podcast = entry
+                .podcast
+                .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()));
+            podcast.season = Some(truncate_to_length(number, limits.max_attribute_length));
+        }
+        if !is_empty {
+            skip_element(reader, buf, limits, depth)?;
+        }
+        Ok(true)
+    } else if tag.starts_with(b"podcast:episode") {
+        if let Some(number) = find_attribute(attrs, b"number") {
+            let podcast = entry
+                .podcast
+                .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()));
+            podcast.episode = Some(truncate_to_length(number, limits.max_attribute_length));
+        }
+        if !is_empty {
+            skip_element(reader, buf, limits, depth)?;
+        }
+        Ok(true)
     } else {
         Ok(false)
     }
@@ -3612,6 +3634,84 @@ mod tests {
         assert_eq!(podcast.persons.len(), 1);
         assert!(podcast.chapters.is_none());
         assert!(podcast.soundbite.is_empty());
+    }
+
+    #[test]
+    fn test_podcast_season_episode_parsed() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <channel>
+                <item>
+                    <title>Episode 42</title>
+                    <podcast:season number="3">Season Three</podcast:season>
+                    <podcast:episode number="42">Bonus</podcast:episode>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        let entry = &feed.entries[0];
+        let podcast = entry
+            .podcast
+            .as_deref()
+            .expect("entry.podcast must be Some");
+        assert_eq!(podcast.season.as_deref(), Some("3"));
+        assert_eq!(podcast.episode.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn test_podcast_season_episode_no_number_attr() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <channel>
+                <item>
+                    <title>Episode 1</title>
+                    <podcast:transcript url="https://example.com/t.txt" type="text/plain"/>
+                    <podcast:season>3</podcast:season>
+                    <podcast:episode>42</podcast:episode>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        let entry = &feed.entries[0];
+        // podcast is Some because transcript forces it; season/episode must be None (no number attr)
+        let podcast = entry
+            .podcast
+            .as_deref()
+            .expect("entry.podcast must be Some due to transcript element");
+        assert!(podcast.season.is_none());
+        assert!(podcast.episode.is_none());
+    }
+
+    #[test]
+    fn test_podcast_season_episode_bozo() {
+        let xml = b"<rss version=\"2.0\" xmlns:podcast=\"https://podcastindex.org/namespace/1.0\"><channel><item><podcast:season number=\"3\">Season Three</channel></rss>";
+
+        let feed = parse_rss20(xml).unwrap();
+        assert!(feed.bozo);
+    }
+
+    #[test]
+    fn test_podcast_season_episode_missing() {
+        let xml = br#"<?xml version="1.0"?>
+        <rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <channel>
+                <item>
+                    <title>Episode 1</title>
+                    <podcast:transcript url="https://example.com/t.txt" type="text/plain"/>
+                </item>
+            </channel>
+        </rss>"#;
+
+        let feed = parse_rss20(xml).unwrap();
+        let entry = &feed.entries[0];
+        let podcast = entry
+            .podcast
+            .as_deref()
+            .expect("entry.podcast must be Some");
+        assert!(podcast.season.is_none());
+        assert!(podcast.episode.is_none());
     }
 
     // PRIORITY 3: Namespace Tests

--- a/crates/feedparser-rs-core/src/types/podcast.rs
+++ b/crates/feedparser-rs-core/src/types/podcast.rs
@@ -474,6 +474,10 @@ pub struct PodcastEntryMeta {
     pub persons: Vec<PodcastPerson>,
     /// Content medium type (podcast:medium)
     pub medium: Option<String>,
+    /// Season number (podcast:season number attribute)
+    pub season: Option<String>,
+    /// Episode number (podcast:episode number attribute)
+    pub episode: Option<String>,
 }
 
 /// Parse iTunes explicit flag from various string representations

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -1514,6 +1514,10 @@ pub struct PodcastEntryMeta {
     pub persons: Vec<PodcastPerson>,
     /// Content medium type (podcast:medium)
     pub medium: Option<String>,
+    /// Season number (podcast:season number attribute)
+    pub season: Option<String>,
+    /// Episode number (podcast:episode number attribute)
+    pub episode: Option<String>,
 }
 
 impl From<CorePodcastEntryMeta> for PodcastEntryMeta {
@@ -1532,6 +1536,8 @@ impl From<CorePodcastEntryMeta> for PodcastEntryMeta {
                 .collect(),
             persons: core.persons.into_iter().map(PodcastPerson::from).collect(),
             medium: core.medium,
+            season: core.season,
+            episode: core.episode,
         }
     }
 }

--- a/crates/feedparser-rs-py/src/lib.rs
+++ b/crates/feedparser-rs-py/src/lib.rs
@@ -39,6 +39,8 @@ fn _feedparser_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<types::podcast::PyPodcastChapters>()?;
     m.add_class::<types::podcast::PyPodcastSoundbite>()?;
     m.add_class::<types::podcast::PyPodcastEntryMeta>()?;
+    m.add_class::<types::podcast::PyPodcastValue>()?;
+    m.add_class::<types::podcast::PyPodcastValueRecipient>()?;
     m.add_class::<types::thread::PyInReplyTo>()?;
     m.add_class::<types::common::PyCloud>()?;
     m.add_class::<types::common::PyTextInput>()?;

--- a/crates/feedparser-rs-py/src/types/podcast.rs
+++ b/crates/feedparser-rs-py/src/types/podcast.rs
@@ -4,7 +4,8 @@ use feedparser_rs::{
     PodcastChapters as CorePodcastChapters, PodcastEntryMeta as CorePodcastEntryMeta,
     PodcastFunding as CorePodcastFunding, PodcastMeta as CorePodcastMeta,
     PodcastPerson as CorePodcastPerson, PodcastSoundbite as CorePodcastSoundbite,
-    PodcastTranscript as CorePodcastTranscript,
+    PodcastTranscript as CorePodcastTranscript, PodcastValue as CorePodcastValue,
+    PodcastValueRecipient as CorePodcastValueRecipient,
 };
 use pyo3::prelude::*;
 
@@ -460,6 +461,14 @@ impl PyPodcastMeta {
         self.inner.locked_owner.as_deref()
     }
 
+    #[getter]
+    fn value(&self) -> Option<PyPodcastValue> {
+        self.inner
+            .value
+            .as_ref()
+            .map(|v| PyPodcastValue::from_core(v.clone()))
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "PodcastMeta(guid='{}', persons={}, medium='{}')",
@@ -764,9 +773,19 @@ impl PyPodcastEntryMeta {
         self.inner.medium.as_deref()
     }
 
+    #[getter]
+    fn season(&self) -> Option<&str> {
+        self.inner.season.as_deref()
+    }
+
+    #[getter]
+    fn episode(&self) -> Option<&str> {
+        self.inner.episode.as_deref()
+    }
+
     fn __repr__(&self) -> String {
         format!(
-            "PodcastEntryMeta(transcripts={}, chapters={}, soundbites={}, persons={})",
+            "PodcastEntryMeta(transcripts={}, chapters={}, soundbites={}, persons={}, season={}, episode={})",
             self.inner.transcript.len(),
             if self.inner.chapters.is_some() {
                 "present"
@@ -774,7 +793,111 @@ impl PyPodcastEntryMeta {
                 "none"
             },
             self.inner.soundbite.len(),
-            self.inner.persons.len()
+            self.inner.persons.len(),
+            self.inner.season.as_deref().unwrap_or("none"),
+            self.inner.episode.as_deref().unwrap_or("none"),
+        )
+    }
+}
+
+#[pyclass(name = "PodcastValue", module = "feedparser_rs", from_py_object)]
+#[derive(Clone)]
+pub struct PyPodcastValue {
+    inner: CorePodcastValue,
+}
+
+impl PyPodcastValue {
+    pub fn from_core(core: CorePodcastValue) -> Self {
+        Self { inner: core }
+    }
+}
+
+#[pymethods]
+impl PyPodcastValue {
+    #[getter]
+    #[pyo3(name = "type")]
+    fn type_(&self) -> &str {
+        &self.inner.type_
+    }
+
+    #[getter]
+    fn method(&self) -> &str {
+        &self.inner.method
+    }
+
+    #[getter]
+    fn suggested(&self) -> Option<&str> {
+        self.inner.suggested.as_deref()
+    }
+
+    #[getter]
+    fn recipients(&self) -> Vec<PyPodcastValueRecipient> {
+        self.inner
+            .recipients
+            .iter()
+            .map(|r| PyPodcastValueRecipient::from_core(r.clone()))
+            .collect()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PodcastValue(type='{}', method='{}', recipients={})",
+            &self.inner.type_,
+            &self.inner.method,
+            self.inner.recipients.len()
+        )
+    }
+}
+
+#[pyclass(
+    name = "PodcastValueRecipient",
+    module = "feedparser_rs",
+    from_py_object
+)]
+#[derive(Clone)]
+pub struct PyPodcastValueRecipient {
+    inner: CorePodcastValueRecipient,
+}
+
+impl PyPodcastValueRecipient {
+    pub fn from_core(core: CorePodcastValueRecipient) -> Self {
+        Self { inner: core }
+    }
+}
+
+#[pymethods]
+impl PyPodcastValueRecipient {
+    #[getter]
+    fn name(&self) -> Option<&str> {
+        self.inner.name.as_deref()
+    }
+
+    #[getter]
+    #[pyo3(name = "type")]
+    fn type_(&self) -> &str {
+        &self.inner.type_
+    }
+
+    #[getter]
+    fn address(&self) -> &str {
+        &self.inner.address
+    }
+
+    #[getter]
+    fn split(&self) -> u32 {
+        self.inner.split
+    }
+
+    #[getter]
+    fn fee(&self) -> Option<bool> {
+        self.inner.fee
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PodcastValueRecipient(name='{}', split={})",
+            self.inner.name.as_deref().unwrap_or("unknown"),
+            self.inner.split
         )
     }
 }


### PR DESCRIPTION
## Summary

- Add `season` and `episode` fields to `PodcastEntryMeta` (core, Node.js, Python bindings), parsed from the `number` attribute of `podcast:season` and `podcast:episode` elements per Podcast 2.0 spec (#332)
- Add `PyPodcastValue` and `PyPodcastValueRecipient` Python wrappers; expose `podcast:value` via `PodcastMeta.value` getter in Python bindings (#337)

## Changes

- `crates/feedparser-rs-core/src/types/podcast.rs` — `season: Option<String>`, `episode: Option<String>` added to `PodcastEntryMeta`
- `crates/feedparser-rs-core/src/parser/rss.rs` — parse `podcast:season` and `podcast:episode` from `number` attribute; 4 new unit tests including bozo test
- `crates/feedparser-rs-node/src/lib.rs` — `season`/`episode` in napi `PodcastEntryMeta`; `PodcastValue`/`PodcastValueRecipient` structs added with `value` field on `PodcastFeedMeta`
- `crates/feedparser-rs-py/src/lib.rs` + `types/podcast.rs` — `PyPodcastValue`, `PyPodcastValueRecipient` wrappers registered; `value` getter on `PyPodcastMeta`; `__repr__` updated

## Test plan

- [ ] 1021 tests pass (`cargo nextest run --all-features --workspace --exclude feedparser-rs-py`)
- [ ] Clippy clean
- [ ] `podcast:season`/`podcast:episode` parsed from `number` attribute
- [ ] Missing `number` attr → `None` (bozo test for malformed element)
- [ ] `podcast:value` accessible in Python via `feed.podcast.value`

Closes #332, closes #337