### PR TITLE
fix(core): resolve namespace extensions by URI instead of hardcoded prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Python binding: `Cloud.registerprocedure` (no underscore) now correctly exposed as `registerprocedure` to match Python feedparser API (#335)
 - Node.js binding: `cloud.registerprocedure` (no underscore) now correctly exposed as `registerprocedure` instead of `registerProcedure` for Python feedparser compatibility (#335)
+- Namespace extension parsers (Dublin Core, Media RSS, iTunes) now resolve namespace URIs instead of matching only hardcoded prefixes; feeds using non-standard prefixes (e.g. `xmlns:dublin="http://purl.org/dc/elements/1.1/"`) are correctly parsed (#334)
 
 ## [0.5.1] - 2026-03-24
 

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -1,5 +1,7 @@
 //! Atom 1.0 parser implementation
 
+use std::collections::HashMap;
+
 use crate::{
     ParserLimits,
     error::{FeedError, Result},
@@ -337,6 +339,7 @@ fn parse_feed_element(
                             &entry_ctx,
                             &mut entry_bozo,
                             effective_lang,
+                            &feed.namespaces,
                         ) {
                             Ok(mut entry) => {
                                 if entry_bozo && !feed.bozo {
@@ -369,7 +372,7 @@ fn parse_feed_element(
                     }
                     tag => {
                         // Check for namespace elements
-                        let handled = if let Some(dc_element) = is_dc_tag(tag) {
+                        let handled = if let Some(dc_element) = is_dc_tag(tag, &feed.namespaces) {
                             let dc_elem = dc_element.to_string();
                             if !is_empty {
                                 let text = read_text_str(reader, &mut buf, limits)?;
@@ -382,7 +385,7 @@ fn parse_feed_element(
                                 skip_element(reader, &mut buf, limits, *depth)?;
                             }
                             true
-                        } else if let Some(media_element) = is_media_tag(tag) {
+                        } else if let Some(media_element) = is_media_tag(tag, &feed.namespaces) {
                             match media_element {
                                 "thumbnail" => {
                                     if let Some(thumb) = MediaThumbnail::from_attributes(
@@ -446,7 +449,7 @@ fn parse_feed_element(
                                 skip_element(reader, &mut buf, limits, *depth)?;
                             }
                             true
-                        } else if is_itunes_tag(tag, b"image") {
+                        } else if is_itunes_tag(tag, b"image", &feed.namespaces) {
                             if let Some(url) = extract_href_attr(&element, limits) {
                                 let itunes = feed
                                     .feed
@@ -468,12 +471,12 @@ fn parse_feed_element(
                                 skip_element(reader, &mut buf, limits, *depth)?;
                             }
                             true
-                        } else if is_itunes_tag(tag, b"category") {
+                        } else if is_itunes_tag(tag, b"category", &feed.namespaces) {
                             parse_atom_itunes_category(
                                 reader, &mut buf, &element, feed, limits, is_empty,
                             )?;
                             true
-                        } else if is_itunes_tag(tag, b"owner") && !is_empty {
+                        } else if is_itunes_tag(tag, b"owner", &feed.namespaces) && !is_empty {
                             if let Ok(owner) =
                                 parse_atom_itunes_owner(reader, &mut buf, limits, depth)
                             {
@@ -484,7 +487,7 @@ fn parse_feed_element(
                                 itunes.owner = Some(owner);
                             }
                             true
-                        } else if is_itunes_tag(tag, b"author") && !is_empty {
+                        } else if is_itunes_tag(tag, b"author", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             if feed.feed.author.is_none() {
                                 feed.feed.set_author(Person::from_name(&text));
@@ -498,7 +501,7 @@ fn parse_feed_element(
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
                             itunes.author = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"subtitle") && !is_empty {
+                        } else if is_itunes_tag(tag, b"subtitle", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -506,7 +509,7 @@ fn parse_feed_element(
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
                             itunes.subtitle = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"summary") && !is_empty {
+                        } else if is_itunes_tag(tag, b"summary", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -514,7 +517,7 @@ fn parse_feed_element(
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
                             itunes.summary = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"explicit") && !is_empty {
+                        } else if is_itunes_tag(tag, b"explicit", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -522,7 +525,7 @@ fn parse_feed_element(
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
                             itunes.explicit = parse_explicit(&text);
                             true
-                        } else if is_itunes_tag(tag, b"keywords") && !is_empty {
+                        } else if is_itunes_tag(tag, b"keywords", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -534,7 +537,7 @@ fn parse_feed_element(
                                 .filter(|s| !s.is_empty())
                                 .collect();
                             true
-                        } else if is_itunes_tag(tag, b"type") && !is_empty {
+                        } else if is_itunes_tag(tag, b"type", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -542,7 +545,7 @@ fn parse_feed_element(
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
                             itunes.podcast_type = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"complete") && !is_empty {
+                        } else if is_itunes_tag(tag, b"complete", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -550,7 +553,8 @@ fn parse_feed_element(
                                 .get_or_insert_with(|| Box::new(ItunesFeedMeta::default()));
                             itunes.complete = Some(text.trim().to_string());
                             true
-                        } else if is_itunes_tag(tag, b"new-feed-url") && !is_empty {
+                        } else if is_itunes_tag(tag, b"new-feed-url", &feed.namespaces) && !is_empty
+                        {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             if !text.is_empty() {
                                 let itunes = feed
@@ -560,7 +564,7 @@ fn parse_feed_element(
                                 itunes.new_feed_url = Some(text.trim().to_string().into());
                             }
                             true
-                        } else if is_itunes_tag(tag, b"block") && !is_empty {
+                        } else if is_itunes_tag(tag, b"block", &feed.namespaces) && !is_empty {
                             let text = read_text_str(reader, &mut buf, limits)?;
                             let itunes = feed
                                 .feed
@@ -615,7 +619,7 @@ fn parse_feed_element(
 }
 
 /// Parse <entry> element
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 fn parse_entry(
     reader: &mut Reader<&[u8]>,
     buf: &mut Vec<u8>,
@@ -624,6 +628,7 @@ fn parse_entry(
     base_ctx: &BaseUrlContext,
     bozo: &mut bool,
     entry_lang: Option<&str>,
+    namespaces: &HashMap<String, String>,
 ) -> Result<Entry> {
     let mut entry = Entry::with_capacity();
 
@@ -770,7 +775,7 @@ fn parse_entry(
                     }
                     tag => {
                         // Check for namespace elements
-                        let handled = if let Some(dc_element) = is_dc_tag(tag) {
+                        let handled = if let Some(dc_element) = is_dc_tag(tag, namespaces) {
                             let dc_elem = dc_element.to_string();
                             if !is_empty {
                                 let (text, had_bozo) = read_text(reader, buf, limits)?;
@@ -792,7 +797,7 @@ fn parse_entry(
                                 );
                             }
                             true
-                        } else if let Some(media_element) = is_media_tag(tag) {
+                        } else if let Some(media_element) = is_media_tag(tag, namespaces) {
                             // Media RSS namespace
                             if media_element == "thumbnail" {
                                 if let Some(thumbnail) = MediaThumbnail::from_attributes(
@@ -817,13 +822,13 @@ fn parse_entry(
                                 }
                                 if !is_empty {
                                     parse_atom_media_content_children(
-                                        reader, buf, &mut entry, limits, depth, bozo,
+                                        reader, buf, &mut entry, limits, depth, bozo, namespaces,
                                     )?;
                                 }
                             } else if media_element == "group" && !is_empty {
                                 // media:group is a transparent container; promote children to entry
                                 parse_atom_media_group(
-                                    reader, buf, &mut entry, limits, depth, bozo,
+                                    reader, buf, &mut entry, limits, depth, bozo, namespaces,
                                 )?;
                             } else if media_element == "credit" {
                                 let role = element
@@ -964,7 +969,7 @@ fn parse_entry(
                                 slash::handle_wfw_entry_element(&wfw_elem, &text, &mut entry);
                             }
                             true
-                        } else if is_itunes_tag(tag, b"image") {
+                        } else if is_itunes_tag(tag, b"image", namespaces) {
                             if let Some(url) = extract_href_attr(&element, limits) {
                                 let itunes = entry
                                     .itunes
@@ -977,7 +982,7 @@ fn parse_entry(
                                 skip_element(reader, buf, limits, *depth)?;
                             }
                             true
-                        } else if is_itunes_tag(tag, b"title") && !is_empty {
+                        } else if is_itunes_tag(tag, b"title", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -985,7 +990,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.title = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"author") && !is_empty {
+                        } else if is_itunes_tag(tag, b"author", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             if entry.author.is_none() {
@@ -999,7 +1004,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.author = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"subtitle") && !is_empty {
+                        } else if is_itunes_tag(tag, b"subtitle", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1007,7 +1012,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.subtitle = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"summary") && !is_empty {
+                        } else if is_itunes_tag(tag, b"summary", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1015,7 +1020,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.summary = Some(text);
                             true
-                        } else if is_itunes_tag(tag, b"duration") && !is_empty {
+                        } else if is_itunes_tag(tag, b"duration", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1023,7 +1028,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.duration = if text.is_empty() { None } else { Some(text) };
                             true
-                        } else if is_itunes_tag(tag, b"explicit") && !is_empty {
+                        } else if is_itunes_tag(tag, b"explicit", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1031,7 +1036,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.explicit = parse_explicit(&text);
                             true
-                        } else if is_itunes_tag(tag, b"episode") && !is_empty {
+                        } else if is_itunes_tag(tag, b"episode", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1039,7 +1044,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.episode = text.trim().parse().ok();
                             true
-                        } else if is_itunes_tag(tag, b"season") && !is_empty {
+                        } else if is_itunes_tag(tag, b"season", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1047,7 +1052,7 @@ fn parse_entry(
                                 .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
                             itunes.season = text.trim().parse().ok();
                             true
-                        } else if is_itunes_tag(tag, b"episodeType") && !is_empty {
+                        } else if is_itunes_tag(tag, b"episodeType", namespaces) && !is_empty {
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
                             let itunes = entry
@@ -1352,17 +1357,18 @@ fn parse_atom_media_group(
     limits: &ParserLimits,
     depth: &mut usize,
     bozo: &mut bool,
+    namespaces: &HashMap<String, String>,
 ) -> Result<()> {
     loop {
         buf.clear();
         match reader.read_event_into(buf) {
             Ok(Event::Empty(e)) => {
                 let tag = e.name().as_ref().to_vec();
-                handle_atom_media_group_child(&tag, &e, entry, limits);
+                handle_atom_media_group_child(&tag, &e, entry, limits, namespaces);
             }
             Ok(Event::Start(e)) => {
                 let tag = e.name().as_ref().to_vec();
-                handle_atom_media_group_child(&tag, &e, entry, limits);
+                handle_atom_media_group_child(&tag, &e, entry, limits, namespaces);
                 *depth += 1;
                 skip_element(reader, buf, limits, *depth)?;
                 *depth = depth.saturating_sub(1);
@@ -1389,13 +1395,14 @@ fn parse_atom_media_content_children(
     limits: &ParserLimits,
     depth: &mut usize,
     bozo: &mut bool,
+    namespaces: &HashMap<String, String>,
 ) -> Result<()> {
     loop {
         buf.clear();
         match reader.read_event_into(buf) {
             Ok(Event::Empty(e)) => {
                 let tag = e.name().as_ref().to_vec();
-                if is_media_tag(&tag) == Some("thumbnail") {
+                if is_media_tag(&tag, namespaces) == Some("thumbnail") {
                     let thumbnail = MediaThumbnail::from_attributes(
                         e.attributes().flatten(),
                         limits.max_attribute_length,
@@ -1409,7 +1416,7 @@ fn parse_atom_media_content_children(
             }
             Ok(Event::Start(e)) => {
                 let tag = e.name().as_ref().to_vec();
-                if is_media_tag(&tag) == Some("thumbnail") {
+                if is_media_tag(&tag, namespaces) == Some("thumbnail") {
                     let thumbnail = MediaThumbnail::from_attributes(
                         e.attributes().flatten(),
                         limits.max_attribute_length,
@@ -1440,8 +1447,9 @@ fn handle_atom_media_group_child(
     element: &quick_xml::events::BytesStart<'_>,
     entry: &mut Entry,
     limits: &ParserLimits,
+    namespaces: &HashMap<String, String>,
 ) {
-    let Some(child_elem) = is_media_tag(tag) else {
+    let Some(child_elem) = is_media_tag(tag, namespaces) else {
         return;
     };
     match child_elem {
@@ -1672,9 +1680,9 @@ fn parse_atom_itunes_owner(
                 *depth += 1;
                 check_depth(*depth, limits.max_nesting_depth)?;
                 let tag_name = e.local_name();
-                if is_itunes_tag(tag_name.as_ref(), b"name") {
+                if tag_name.as_ref() == b"name" {
                     owner.name = Some(read_text_str(reader, buf, limits)?);
-                } else if is_itunes_tag(tag_name.as_ref(), b"email") {
+                } else if tag_name.as_ref() == b"email" {
                     owner.email = Some(read_text_str(reader, buf, limits)?);
                 } else {
                     skip_element(reader, buf, limits, *depth)?;
@@ -1718,14 +1726,18 @@ fn parse_atom_itunes_category(
         loop {
             buf.clear();
             match reader.read_event_into(buf) {
-                Ok(Event::Empty(e)) if is_itunes_tag(e.name().as_ref(), b"category") => {
+                Ok(Event::Empty(e))
+                    if is_itunes_tag(e.name().as_ref(), b"category", &feed.namespaces) =>
+                {
                     subcategory = e
                         .attributes()
                         .flatten()
                         .find(|a| a.key.as_ref() == b"text")
                         .and_then(|a| String::from_utf8(a.value.into_owned()).ok());
                 }
-                Ok(Event::Start(e)) if is_itunes_tag(e.name().as_ref(), b"category") => {
+                Ok(Event::Start(e))
+                    if is_itunes_tag(e.name().as_ref(), b"category", &feed.namespaces) =>
+                {
                     subcategory = e
                         .attributes()
                         .flatten()

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -6,13 +6,14 @@
 use crate::{
     ParserLimits,
     error::{FeedError, Result},
+    namespace::namespaces as ns_uris,
     types::{FeedVersion, ParsedFeed},
 };
 use quick_xml::{
     Reader,
     events::{BytesRef, Event},
 };
-use std::io::Write as _;
+use std::{collections::HashMap, io::Write as _};
 
 pub use crate::types::{FromAttributes, LimitedCollectionExt};
 pub use crate::util::text::bytes_to_string;
@@ -189,18 +190,69 @@ pub fn extract_ns_local_name<'a>(name: &'a [u8], prefix: &[u8]) -> Option<&'a st
     }
 }
 
-/// Check if element is a Dublin Core namespaced tag
+/// Split a namespaced tag into `(prefix_bytes_with_colon, local_name_bytes)`.
+///
+/// Returns `None` if there is no colon separator or the local name is empty.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// assert_eq!(is_dc_tag(b"dc:creator"), Some("creator"));
-/// assert_eq!(is_dc_tag(b"dc:subject"), Some("subject"));
-/// assert_eq!(is_dc_tag(b"content:encoded"), None);
+/// assert_eq!(split_ns_tag(b"dc:creator"), Some((b"dc:" as &[u8], b"creator" as &[u8])));
+/// assert_eq!(split_ns_tag(b"title"), None); // no prefix
+/// assert_eq!(split_ns_tag(b"dc:"), None);  // empty local name
 /// ```
 #[inline]
-pub fn is_dc_tag(name: &[u8]) -> Option<&str> {
-    extract_ns_local_name(name, b"dc:")
+fn split_ns_tag(name: &[u8]) -> Option<(&[u8], &[u8])> {
+    let colon = name.iter().position(|&b| b == b':')?;
+    let local = &name[colon + 1..];
+    if local.is_empty() {
+        return None;
+    }
+    Some((&name[..=colon], local))
+}
+
+/// Match a tag against a namespace URI using the declared prefix mapping.
+///
+/// Resolves the tag prefix via `namespaces` (prefix → URI) and checks whether
+/// the resolved URI equals `target_uri`. If it does, returns the local element
+/// name (validated as alphanumeric/hyphen/underscore). Falls back to checking
+/// the canonical hardcoded prefix when the resolved prefix is absent from the map.
+#[inline]
+fn match_ns_tag_by_uri<'a>(
+    name: &'a [u8],
+    canonical_prefix: &[u8],
+    target_uri: &str,
+    namespaces: &HashMap<String, String>,
+) -> Option<&'a str> {
+    // Fast path: canonical prefix (e.g. "dc:")
+    if let Some(local) = extract_ns_local_name(name, canonical_prefix) {
+        return Some(local);
+    }
+    // URI-based fallback: find any declared prefix that maps to target_uri
+    let (prefix_with_colon, _) = split_ns_tag(name)?;
+    let prefix_str = std::str::from_utf8(&prefix_with_colon[..prefix_with_colon.len() - 1]).ok()?;
+    if namespaces.get(prefix_str).map(String::as_str) == Some(target_uri) {
+        extract_ns_local_name(name, prefix_with_colon)
+    } else {
+        None
+    }
+}
+
+/// Check if element is a Dublin Core namespaced tag.
+///
+/// Recognises the canonical `dc:` prefix and any custom prefix declared with
+/// `xmlns:X="http://purl.org/dc/elements/1.1/"`.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(is_dc_tag(b"dc:creator", &namespaces), Some("creator"));
+/// assert_eq!(is_dc_tag(b"dublin:creator", &namespaces_with_dublin_uri), Some("creator"));
+/// assert_eq!(is_dc_tag(b"content:encoded", &namespaces), None);
+/// ```
+#[inline]
+pub fn is_dc_tag<'a>(name: &'a [u8], namespaces: &HashMap<String, String>) -> Option<&'a str> {
+    match_ns_tag_by_uri(name, b"dc:", ns_uris::DUBLIN_CORE, namespaces)
 }
 
 /// Check if element is a Content namespaced tag
@@ -239,13 +291,13 @@ pub fn is_syn_tag(name: &[u8]) -> Option<&str> {
 /// # Examples
 ///
 /// ```ignore
-/// assert_eq!(is_media_tag(b"media:thumbnail"), Some("thumbnail"));
-/// assert_eq!(is_media_tag(b"media:content"), Some("content"));
-/// assert_eq!(is_media_tag(b"dc:creator"), None);
+/// assert_eq!(is_media_tag(b"media:thumbnail", &namespaces), Some("thumbnail"));
+/// assert_eq!(is_media_tag(b"mrss:content", &namespaces_with_mrss_uri), Some("content"));
+/// assert_eq!(is_media_tag(b"dc:creator", &namespaces), None);
 /// ```
 #[inline]
-pub fn is_media_tag(name: &[u8]) -> Option<&str> {
-    extract_ns_local_name(name, b"media:")
+pub fn is_media_tag<'a>(name: &'a [u8], namespaces: &HashMap<String, String>) -> Option<&'a str> {
+    match_ns_tag_by_uri(name, b"media:", ns_uris::MEDIA, namespaces)
 }
 
 /// Check if element is a Slash namespaced tag
@@ -316,25 +368,32 @@ pub fn is_thr_tag(name: &[u8]) -> Option<&str> {
     extract_ns_local_name(name, b"thr:")
 }
 
-/// Check if element matches an iTunes namespace tag
+/// Check if element matches an iTunes namespace tag.
 ///
-/// Supports both prefixed (itunes:author) and unprefixed (author) forms
-/// for compatibility with non-compliant feeds.
+/// Resolves the canonical `itunes:` prefix and any custom prefix declared with
+/// `xmlns:X="http://www.itunes.com/dtds/podcast-1.0.dtd"`. Also supports
+/// unprefixed element names for compatibility with non-compliant feeds.
+/// Local name is validated (alphanumeric, hyphen, underscore only) via
+/// `match_ns_tag_by_uri`.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// assert!(is_itunes_tag(b"itunes:author", b"author"));
-/// assert!(is_itunes_tag(b"author", b"author")); // Fallback for non-prefixed
-/// assert!(!is_itunes_tag(b"itunes:title", b"author"));
+/// assert!(is_itunes_tag(b"itunes:author", b"author", &namespaces));
+/// assert!(is_itunes_tag(b"author", b"author", &namespaces)); // Fallback for non-prefixed
+/// assert!(!is_itunes_tag(b"itunes:title", b"author", &namespaces));
 /// ```
 #[inline]
-pub fn is_itunes_tag(name: &[u8], tag: &[u8]) -> bool {
-    if name.starts_with(b"itunes:") && &name[7..] == tag {
-        return true;
+pub fn is_itunes_tag(name: &[u8], tag: &[u8], namespaces: &HashMap<String, String>) -> bool {
+    // Prefixed: resolve via URI and validate local name via match_ns_tag_by_uri
+    if let Some(local) = match_ns_tag_by_uri(name, b"itunes:", ns_uris::ITUNES, namespaces) {
+        return local.as_bytes() == tag;
     }
-    // Fallback for feeds without prefix
-    name == tag
+    // Fallback for feeds without prefix: compare directly (no colon means no namespace)
+    if !name.contains(&b':') {
+        return name == tag;
+    }
+    false
 }
 
 /// Extract xml:base attribute from element
@@ -1300,5 +1359,89 @@ mod tests {
         let feed = parse_namespaces_from_element(xml.as_bytes(), &limits);
         assert!(feed.bozo);
         assert!(feed.namespaces.is_empty());
+    }
+
+    #[test]
+    fn test_is_dc_tag_custom_prefix() {
+        let mut ns = HashMap::new();
+        ns.insert(
+            "dublin".to_string(),
+            "http://purl.org/dc/elements/1.1/".to_string(),
+        );
+        assert_eq!(is_dc_tag(b"dublin:creator", &ns), Some("creator"));
+        assert_eq!(is_dc_tag(b"dublin:date", &ns), Some("date"));
+        // canonical prefix still works
+        let empty = HashMap::new();
+        assert_eq!(is_dc_tag(b"dc:creator", &empty), Some("creator"));
+        // unrelated prefix does not match
+        assert!(is_dc_tag(b"foo:creator", &ns).is_none());
+    }
+
+    #[test]
+    fn test_is_media_tag_custom_prefix() {
+        let mut ns = HashMap::new();
+        ns.insert(
+            "mrss".to_string(),
+            "http://search.yahoo.com/mrss/".to_string(),
+        );
+        assert_eq!(is_media_tag(b"mrss:thumbnail", &ns), Some("thumbnail"));
+        assert_eq!(is_media_tag(b"mrss:content", &ns), Some("content"));
+        // canonical prefix still works
+        let empty = HashMap::new();
+        assert_eq!(is_media_tag(b"media:thumbnail", &empty), Some("thumbnail"));
+        // unrelated prefix does not match
+        assert!(is_media_tag(b"foo:thumbnail", &ns).is_none());
+    }
+
+    #[test]
+    fn test_is_itunes_tag_custom_prefix() {
+        let mut ns = HashMap::new();
+        ns.insert(
+            "podcast".to_string(),
+            "http://www.itunes.com/dtds/podcast-1.0.dtd".to_string(),
+        );
+        assert!(is_itunes_tag(b"podcast:author", b"author", &ns));
+        assert!(is_itunes_tag(b"podcast:explicit", b"explicit", &ns));
+        // canonical prefix still works
+        let empty = HashMap::new();
+        assert!(is_itunes_tag(b"itunes:author", b"author", &empty));
+        // unrelated prefix does not match
+        assert!(!is_itunes_tag(b"foo:author", b"author", &ns));
+    }
+
+    #[test]
+    fn test_ns_tag_with_invalid_security_chars() {
+        let mut ns = HashMap::new();
+        ns.insert(
+            "dublin".to_string(),
+            "http://purl.org/dc/elements/1.1/".to_string(),
+        );
+        // Security: invalid chars in local name must be rejected
+        assert!(is_dc_tag(b"dublin:../../etc/passwd", &ns).is_none());
+        assert!(is_dc_tag(b"dublin:tag<script>", &ns).is_none());
+    }
+
+    #[test]
+    fn test_is_itunes_tag_security() {
+        let empty = HashMap::new();
+        // Path traversal in local name must not match
+        assert!(!is_itunes_tag(
+            b"itunes:../../etc/passwd",
+            b"../../etc/passwd",
+            &empty
+        ));
+        // Same with custom prefix
+        let mut ns = HashMap::new();
+        ns.insert(
+            "it".to_string(),
+            "http://www.itunes.com/dtds/podcast-1.0.dtd".to_string(),
+        );
+        assert!(!is_itunes_tag(
+            b"it:../../etc/passwd",
+            b"../../etc/passwd",
+            &ns
+        ));
+        // Unprefixed path traversal also rejected (no colon → direct match, but value differs)
+        assert!(!is_itunes_tag(b"../../etc/passwd", b"author", &empty));
     }
 }

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1,5 +1,7 @@
 //! RSS 2.0 parser implementation
 
+use std::collections::HashMap;
+
 use crate::{
     ParserLimits,
     error::{FeedError, Result},
@@ -404,7 +406,15 @@ fn parse_channel_item(
 
     let effective_lang = item_lang.or(channel_lang);
 
-    match parse_item(reader, buf, limits, depth, base_ctx, effective_lang) {
+    match parse_item(
+        reader,
+        buf,
+        limits,
+        depth,
+        base_ctx,
+        effective_lang,
+        &feed.namespaces,
+    ) {
         Ok((mut entry, has_attr_errors, has_entity_bozo)) => {
             if has_attr_errors {
                 feed.bozo = true;
@@ -672,7 +682,7 @@ fn parse_channel_itunes(
     depth: &mut usize,
     is_empty: bool,
 ) -> Result<bool> {
-    if is_itunes_tag(tag, b"author") {
+    if is_itunes_tag(tag, b"author", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             // Store raw value; author promotion happens in apply_itunes_feed_promotions
@@ -684,7 +694,7 @@ fn parse_channel_itunes(
             itunes.author = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"subtitle") {
+    } else if is_itunes_tag(tag, b"subtitle", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -694,7 +704,7 @@ fn parse_channel_itunes(
             itunes.subtitle = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"summary") {
+    } else if is_itunes_tag(tag, b"summary", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -704,7 +714,7 @@ fn parse_channel_itunes(
             itunes.summary = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"owner") {
+    } else if is_itunes_tag(tag, b"owner", &feed.namespaces) {
         if !is_empty && let Ok(owner) = parse_itunes_owner(reader, buf, limits, depth) {
             // Promote to publisher_detail if not already set
             if feed.feed.publisher_detail.is_none() {
@@ -723,10 +733,10 @@ fn parse_channel_itunes(
             itunes.owner = Some(owner);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"category") {
+    } else if is_itunes_tag(tag, b"category", &feed.namespaces) {
         parse_itunes_category(reader, buf, attrs, feed, limits, is_empty);
         Ok(true)
-    } else if is_itunes_tag(tag, b"explicit") {
+    } else if is_itunes_tag(tag, b"explicit", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -736,7 +746,7 @@ fn parse_channel_itunes(
             itunes.explicit = parse_explicit(&text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"image") {
+    } else if is_itunes_tag(tag, b"image", &feed.namespaces) {
         if let Some(value) = find_attribute(attrs, b"href") {
             let url = truncate_to_length(value, limits.max_attribute_length);
             let itunes = feed
@@ -756,7 +766,7 @@ fn parse_channel_itunes(
             });
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"keywords") {
+    } else if is_itunes_tag(tag, b"keywords", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -770,7 +780,7 @@ fn parse_channel_itunes(
                 .collect();
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"type") {
+    } else if is_itunes_tag(tag, b"type", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -780,7 +790,7 @@ fn parse_channel_itunes(
             itunes.podcast_type = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"complete") {
+    } else if is_itunes_tag(tag, b"complete", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -790,7 +800,7 @@ fn parse_channel_itunes(
             itunes.complete = Some(text.trim().to_string());
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"new-feed-url") {
+    } else if is_itunes_tag(tag, b"new-feed-url", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             if !text.is_empty() {
@@ -802,7 +812,7 @@ fn parse_channel_itunes(
             }
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"block") {
+    } else if is_itunes_tag(tag, b"block", &feed.namespaces) {
         if !is_empty {
             let text = read_text_str(reader, buf, limits)?;
             let itunes = feed
@@ -837,7 +847,7 @@ fn parse_itunes_category(
         loop {
             match reader.read_event_into(buf) {
                 Ok(Event::Start(sub_e)) => {
-                    if is_itunes_tag(sub_e.name().as_ref(), b"category") {
+                    if is_itunes_tag(sub_e.name().as_ref(), b"category", &feed.namespaces) {
                         nesting += 1;
                         if nesting == 1 {
                             for attr in sub_e.attributes().flatten() {
@@ -854,7 +864,7 @@ fn parse_itunes_category(
                     }
                 }
                 Ok(Event::Empty(sub_e)) => {
-                    if is_itunes_tag(sub_e.name().as_ref(), b"category")
+                    if is_itunes_tag(sub_e.name().as_ref(), b"category", &feed.namespaces)
                         && subcategory_text.is_none()
                     {
                         for attr in sub_e.attributes().flatten() {
@@ -869,7 +879,7 @@ fn parse_itunes_category(
                     }
                 }
                 Ok(Event::End(end_e)) => {
-                    if is_itunes_tag(end_e.name().as_ref(), b"category") {
+                    if is_itunes_tag(end_e.name().as_ref(), b"category", &feed.namespaces) {
                         if nesting == 0 {
                             break;
                         }
@@ -1045,7 +1055,7 @@ fn parse_channel_namespace(
     depth: usize,
     is_empty: bool,
 ) -> Result<bool> {
-    if let Some(dc_element) = is_dc_tag(tag) {
+    if let Some(dc_element) = is_dc_tag(tag, &feed.namespaces) {
         if !is_empty {
             let dc_elem = dc_element.to_string();
             let text = read_text_str(reader, buf, limits)?;
@@ -1057,7 +1067,7 @@ fn parse_channel_namespace(
             skip_element(reader, buf, limits, depth)?;
         }
         Ok(true)
-    } else if let Some(media_element) = is_media_tag(tag) {
+    } else if let Some(media_element) = is_media_tag(tag, &feed.namespaces) {
         match media_element {
             "thumbnail" => {
                 let url = find_attribute(attrs, b"url")
@@ -1194,6 +1204,7 @@ fn parse_item(
     depth: &mut usize,
     base_ctx: &BaseUrlContext,
     item_lang: Option<&str>,
+    namespaces: &HashMap<String, String>,
 ) -> Result<(Entry, bool, bool)> {
     let mut entry = Entry::with_capacity();
     let mut has_attr_errors = false;
@@ -1276,6 +1287,7 @@ fn parse_item(
                             is_empty,
                             *depth,
                             &mut has_entity_bozo,
+                            namespaces,
                         )?;
                         if !handled {
                             handled = parse_item_podcast(
@@ -1295,6 +1307,7 @@ fn parse_item(
                                 &mut has_entity_bozo,
                                 item_lang,
                                 base_ctx.base(),
+                                namespaces,
                             )?;
                         }
 
@@ -1466,8 +1479,9 @@ fn parse_item_itunes(
     is_empty: bool,
     depth: usize,
     bozo: &mut bool,
+    namespaces: &HashMap<String, String>,
 ) -> Result<bool> {
-    if is_itunes_tag(tag, b"title") {
+    if is_itunes_tag(tag, b"title", namespaces) {
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
         let itunes = entry
@@ -1475,7 +1489,7 @@ fn parse_item_itunes(
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
         itunes.title = Some(text);
         Ok(true)
-    } else if is_itunes_tag(tag, b"author") {
+    } else if is_itunes_tag(tag, b"author", namespaces) {
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
         // Promote to entry.author if not already set
@@ -1490,7 +1504,7 @@ fn parse_item_itunes(
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
         itunes.author = Some(text);
         Ok(true)
-    } else if is_itunes_tag(tag, b"subtitle") {
+    } else if is_itunes_tag(tag, b"subtitle", namespaces) {
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
         let itunes = entry
@@ -1498,7 +1512,7 @@ fn parse_item_itunes(
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
         itunes.subtitle = Some(text);
         Ok(true)
-    } else if is_itunes_tag(tag, b"summary") {
+    } else if is_itunes_tag(tag, b"summary", namespaces) {
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
         let itunes = entry
@@ -1506,7 +1520,7 @@ fn parse_item_itunes(
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
         itunes.summary = Some(text);
         Ok(true)
-    } else if is_itunes_tag(tag, b"duration") {
+    } else if is_itunes_tag(tag, b"duration", namespaces) {
         let text = read_text_str(reader, buf, limits)?;
         let itunes = entry
             .itunes
@@ -1515,14 +1529,14 @@ fn parse_item_itunes(
             itunes.duration = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"explicit") {
+    } else if is_itunes_tag(tag, b"explicit", namespaces) {
         let text = read_text_str(reader, buf, limits)?;
         let itunes = entry
             .itunes
             .get_or_insert_with(|| Box::new(ItunesEntryMeta::default()));
         itunes.explicit = parse_explicit(&text);
         Ok(true)
-    } else if is_itunes_tag(tag, b"image") {
+    } else if is_itunes_tag(tag, b"image", namespaces) {
         if let Some(value) = find_attribute(attrs, b"href") {
             let itunes = entry
                 .itunes
@@ -1533,7 +1547,7 @@ fn parse_item_itunes(
             skip_element(reader, buf, limits, depth)?;
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"episode") {
+    } else if is_itunes_tag(tag, b"episode", namespaces) {
         let text = read_text_str(reader, buf, limits)?;
         let itunes = entry
             .itunes
@@ -1542,7 +1556,7 @@ fn parse_item_itunes(
             itunes.episode = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"season") {
+    } else if is_itunes_tag(tag, b"season", namespaces) {
         let text = read_text_str(reader, buf, limits)?;
         let itunes = entry
             .itunes
@@ -1551,7 +1565,7 @@ fn parse_item_itunes(
             itunes.season = Some(text);
         }
         Ok(true)
-    } else if is_itunes_tag(tag, b"episodeType") {
+    } else if is_itunes_tag(tag, b"episodeType", namespaces) {
         let text = read_text_str(reader, buf, limits)?;
         let itunes = entry
             .itunes
@@ -1814,8 +1828,9 @@ fn parse_item_namespace(
     bozo: &mut bool,
     lang: Option<&str>,
     base: Option<&str>,
+    namespaces: &HashMap<String, String>,
 ) -> Result<bool> {
-    if let Some(dc_element) = is_dc_tag(tag) {
+    if let Some(dc_element) = is_dc_tag(tag, namespaces) {
         let dc_elem = dc_element.to_string();
         let (text, had_bozo) = read_text(reader, buf, limits)?;
         *bozo |= had_bozo;
@@ -1851,7 +1866,7 @@ fn parse_item_namespace(
         *bozo |= had_bozo;
         slash::handle_wfw_entry_element(&wfw_elem, &text, entry);
         Ok(true)
-    } else if let Some(media_element) = is_media_tag(tag) {
+    } else if let Some(media_element) = is_media_tag(tag, namespaces) {
         parse_item_media(
             reader,
             buf,
@@ -1861,6 +1876,7 @@ fn parse_item_namespace(
             limits,
             is_empty,
             depth,
+            namespaces,
         )?;
         Ok(true)
     } else if tag.starts_with(b"creativeCommons:license") || tag == b"license" {
@@ -1910,6 +1926,7 @@ fn parse_item_media(
     limits: &ParserLimits,
     is_empty: bool,
     depth: usize,
+    namespaces: &HashMap<String, String>,
 ) -> Result<()> {
     match media_element {
         "thumbnail" => {
@@ -1979,7 +1996,7 @@ fn parse_item_media(
                 );
             }
             if !is_empty {
-                parse_media_content_children(reader, buf, entry, limits, depth)?;
+                parse_media_content_children(reader, buf, entry, limits, depth, namespaces)?;
             }
         }
         "rating" => {
@@ -1993,7 +2010,7 @@ fn parse_item_media(
             // media:group is a transparent container; parse its children as if they
             // were direct siblings of the enclosing item.
             if !is_empty {
-                parse_media_group(reader, buf, entry, limits, depth)?;
+                parse_media_group(reader, buf, entry, limits, depth, namespaces)?;
             }
         }
         "credit" => {
@@ -2056,6 +2073,7 @@ fn parse_media_group(
     entry: &mut Entry,
     limits: &ParserLimits,
     depth: usize,
+    namespaces: &HashMap<String, String>,
 ) -> Result<()> {
     let mut inner_depth = depth;
     loop {
@@ -2066,7 +2084,7 @@ fn parse_media_group(
                 check_depth(inner_depth, limits.max_nesting_depth)?;
                 let tag = e.name().as_ref().to_vec();
                 let (attrs, _) = collect_attributes(&e);
-                if let Some(media_element) = is_media_tag(&tag) {
+                if let Some(media_element) = is_media_tag(&tag, namespaces) {
                     parse_item_media(
                         reader,
                         buf,
@@ -2076,6 +2094,7 @@ fn parse_media_group(
                         limits,
                         false,
                         inner_depth,
+                        namespaces,
                     )?;
                 } else {
                     skip_element(reader, buf, limits, inner_depth)?;
@@ -2085,7 +2104,7 @@ fn parse_media_group(
             Ok(Event::Empty(e)) => {
                 let tag = e.name().as_ref().to_vec();
                 let (attrs, _) = collect_attributes(&e);
-                if let Some(media_element) = is_media_tag(&tag) {
+                if let Some(media_element) = is_media_tag(&tag, namespaces) {
                     parse_item_media(
                         reader,
                         buf,
@@ -2095,6 +2114,7 @@ fn parse_media_group(
                         limits,
                         true,
                         inner_depth,
+                        namespaces,
                     )?;
                 }
             }
@@ -2115,6 +2135,7 @@ fn parse_media_content_children(
     entry: &mut Entry,
     limits: &ParserLimits,
     depth: usize,
+    namespaces: &HashMap<String, String>,
 ) -> Result<()> {
     let mut inner_depth = depth;
     loop {
@@ -2124,7 +2145,7 @@ fn parse_media_content_children(
                 inner_depth += 1;
                 check_depth(inner_depth, limits.max_nesting_depth)?;
                 let tag = e.name().as_ref().to_vec();
-                if is_media_tag(&tag) == Some("thumbnail") {
+                if is_media_tag(&tag, namespaces) == Some("thumbnail") {
                     let (attrs, _) = collect_attributes(&e);
                     let url = find_attribute(&attrs, b"url")
                         .map(|v| truncate_to_length(v, limits.max_attribute_length))
@@ -2149,7 +2170,7 @@ fn parse_media_content_children(
             }
             Ok(Event::Empty(e)) => {
                 let tag = e.name().as_ref().to_vec();
-                if is_media_tag(&tag) == Some("thumbnail") {
+                if is_media_tag(&tag, namespaces) == Some("thumbnail") {
                     let (attrs, _) = collect_attributes(&e);
                     let url = find_attribute(&attrs, b"url")
                         .map(|v| truncate_to_length(v, limits.max_attribute_length))
@@ -2382,9 +2403,9 @@ fn parse_itunes_owner(
                 check_depth(*depth, limits.max_nesting_depth)?;
 
                 let tag_name = e.local_name();
-                if is_itunes_tag(tag_name.as_ref(), b"name") {
+                if tag_name.as_ref() == b"name" {
                     owner.name = Some(read_text_str(reader, buf, limits)?);
-                } else if is_itunes_tag(tag_name.as_ref(), b"email") {
+                } else if tag_name.as_ref() == b"email" {
                     owner.email = Some(read_text_str(reader, buf, limits)?);
                 } else {
                     skip_element(reader, buf, limits, *depth)?;
@@ -5317,5 +5338,41 @@ mod tests {
         let podcast = feed.feed.podcast.as_ref().unwrap();
         assert_eq!(podcast.locked.as_deref(), Some("no"));
         assert!(podcast.locked_owner.is_none());
+    }
+
+    #[test]
+    fn test_rss20_custom_dc_prefix() {
+        let xml = include_bytes!("../../../../tests/fixtures/rss/custom_ns_dc.xml");
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo, "bozo_exception: {:?}", feed.bozo_exception);
+        // dc:creator at channel level should be parsed
+        assert_eq!(feed.feed.author.as_deref(), Some("Test Author"));
+        // dc:creator at item level should be parsed
+        assert!(!feed.entries.is_empty());
+        assert_eq!(feed.entries[0].author.as_deref(), Some("Item Author"));
+        // mrss:thumbnail should be parsed
+        assert!(!feed.entries[0].media_thumbnail.is_empty());
+    }
+
+    #[test]
+    fn test_rss20_custom_itunes_prefix() {
+        let xml = include_bytes!("../../../../tests/fixtures/rss/custom_ns_itunes.xml");
+        let feed = parse_rss20(xml).unwrap();
+        assert!(!feed.bozo, "bozo_exception: {:?}", feed.bozo_exception);
+        // it:author at channel level should be parsed
+        let itunes = feed
+            .feed
+            .itunes
+            .as_ref()
+            .expect("itunes metadata should be present");
+        assert_eq!(itunes.author.as_deref(), Some("John Doe"));
+        // it:duration at item level should be parsed
+        assert!(!feed.entries.is_empty());
+        let entry_itunes = feed.entries[0]
+            .itunes
+            .as_ref()
+            .expect("entry itunes metadata");
+        assert_eq!(entry_itunes.duration.as_deref(), Some("30:00"));
+        assert_eq!(entry_itunes.author.as_deref(), Some("Jane Smith"));
     }
 }

--- a/crates/feedparser-rs-core/src/parser/rss10.rs
+++ b/crates/feedparser-rs-core/src/parser/rss10.rs
@@ -7,6 +7,8 @@
 //! - Items have `rdf:about` attributes for identification
 //! - Supports Dublin Core and other RDF vocabularies
 
+use std::collections::HashMap;
+
 use crate::{
     ParserLimits,
     error::{FeedError, Result},
@@ -162,6 +164,7 @@ pub fn parse_rss10_with_limits(data: &[u8], limits: ParserLimits) -> Result<Pars
                         &mut item_bozo,
                         effective_item_lang,
                         &item_base_ctx,
+                        &feed.namespaces,
                     ) {
                         Ok(entry) => {
                             if item_bozo && !feed.bozo {
@@ -261,7 +264,7 @@ fn parse_channel(
                     }
                     _ => {
                         // Check for Dublin Core and other namespace tags
-                        if let Some(dc_element) = is_dc_tag(full_name.as_ref()) {
+                        if let Some(dc_element) = is_dc_tag(full_name.as_ref(), &feed.namespaces) {
                             let dc_elem = dc_element.to_string();
                             let text = read_text_str(reader, &mut buf, limits)?;
                             dublin_core::handle_feed_element(&dc_elem, &text, &mut feed.feed);
@@ -317,6 +320,7 @@ fn parse_item(
     bozo: &mut bool,
     lang: Option<&str>,
     base_ctx: &BaseUrlContext,
+    namespaces: &HashMap<String, String>,
 ) -> Result<Entry> {
     let mut entry = Entry::with_capacity();
     entry.id = item_id.map(std::convert::Into::into);
@@ -364,7 +368,7 @@ fn parse_item(
                     }
                     _ => {
                         // Check for Dublin Core and other namespace tags
-                        if let Some(dc_element) = is_dc_tag(full_name.as_ref()) {
+                        if let Some(dc_element) = is_dc_tag(full_name.as_ref(), namespaces) {
                             let dc_elem = dc_element.to_string();
                             let (text, had_bozo) = read_text(reader, buf, limits)?;
                             *bozo |= had_bozo;
@@ -682,35 +686,38 @@ mod tests {
 
     #[test]
     fn test_is_dc_tag_valid() {
-        assert_eq!(is_dc_tag(b"dc:creator"), Some("creator"));
-        assert_eq!(is_dc_tag(b"dc:date"), Some("date"));
-        assert_eq!(is_dc_tag(b"dc:description"), Some("description"));
-        assert_eq!(is_dc_tag(b"dc:subject"), Some("subject"));
-        assert_eq!(is_dc_tag(b"dc:content-type"), Some("content-type"));
+        let ns = HashMap::new();
+        assert_eq!(is_dc_tag(b"dc:creator", &ns), Some("creator"));
+        assert_eq!(is_dc_tag(b"dc:date", &ns), Some("date"));
+        assert_eq!(is_dc_tag(b"dc:description", &ns), Some("description"));
+        assert_eq!(is_dc_tag(b"dc:subject", &ns), Some("subject"));
+        assert_eq!(is_dc_tag(b"dc:content-type", &ns), Some("content-type"));
     }
 
     #[test]
     fn test_is_dc_tag_rejects_malicious() {
+        let ns = HashMap::new();
         // Path traversal attempts
-        assert!(is_dc_tag(b"dc:../../etc/passwd").is_none());
-        assert!(is_dc_tag(b"dc:../../../root").is_none());
+        assert!(is_dc_tag(b"dc:../../etc/passwd", &ns).is_none());
+        assert!(is_dc_tag(b"dc:../../../root", &ns).is_none());
 
         // Special characters
-        assert!(is_dc_tag(b"dc:invalid<tag>").is_none());
-        assert!(is_dc_tag(b"dc:tag&name").is_none());
-        assert!(is_dc_tag(b"dc:tag;name").is_none());
-        assert!(is_dc_tag(b"dc:tag/name").is_none());
-        assert!(is_dc_tag(b"dc:tag\\name").is_none());
+        assert!(is_dc_tag(b"dc:invalid<tag>", &ns).is_none());
+        assert!(is_dc_tag(b"dc:tag&name", &ns).is_none());
+        assert!(is_dc_tag(b"dc:tag;name", &ns).is_none());
+        assert!(is_dc_tag(b"dc:tag/name", &ns).is_none());
+        assert!(is_dc_tag(b"dc:tag\\name", &ns).is_none());
 
         // Empty tag name
-        assert!(is_dc_tag(b"dc:").is_none());
+        assert!(is_dc_tag(b"dc:", &ns).is_none());
     }
 
     #[test]
     fn test_is_dc_tag_non_dc() {
-        assert!(is_dc_tag(b"title").is_none());
-        assert!(is_dc_tag(b"link").is_none());
-        assert!(is_dc_tag(b"atom:title").is_none());
+        let ns = HashMap::new();
+        assert!(is_dc_tag(b"title", &ns).is_none());
+        assert!(is_dc_tag(b"link", &ns).is_none());
+        assert!(is_dc_tag(b"atom:title", &ns).is_none());
     }
 
     #[test]

--- a/tests/fixtures/rss/custom_ns_dc.xml
+++ b/tests/fixtures/rss/custom_ns_dc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:dublin="http://purl.org/dc/elements/1.1/"
+     xmlns:mrss="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Custom Prefix Test</title>
+    <link>https://example.com</link>
+    <dublin:creator>Test Author</dublin:creator>
+    <item>
+      <title>Item 1</title>
+      <dublin:creator>Item Author</dublin:creator>
+      <dublin:subject>Testing</dublin:subject>
+      <mrss:thumbnail url="https://example.com/thumb.jpg"/>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/rss/custom_ns_itunes.xml
+++ b/tests/fixtures/rss/custom_ns_itunes.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:it="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Custom iTunes Prefix Test</title>
+    <link>https://example.com</link>
+    <it:author>John Doe</it:author>
+    <it:explicit>no</it:explicit>
+    <item>
+      <title>Episode 1</title>
+      <it:duration>30:00</it:duration>
+      <it:explicit>no</it:explicit>
+      <it:author>Jane Smith</it:author>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- `is_dc_tag`, `is_media_tag`, `is_itunes_tag` in `common.rs` now resolve the tag prefix to a namespace URI via the feed's `namespaces` map and compare against the canonical URI, instead of matching hardcoded prefix bytes
- New helpers `split_ns_tag` and `match_ns_tag_by_uri` implement the URI-based lookup with canonical-prefix fast-path fallback
- `namespaces: &HashMap<String, String>` propagated through affected call chains in `rss.rs`, `atom.rs`, `rss10.rs`
- Integration test fixtures and tests added for custom DC (`xmlns:dublin`) and iTunes (`xmlns:it`) prefixes
- Security: path-traversal local names (`../../etc/passwd`) rejected for all three namespace helpers

Fixes #334

## Test plan

- [ ] `cargo nextest run --all-features --workspace --exclude feedparser-rs-py` — 1024 passed
- [ ] `cargo clippy --all-targets --all-features --workspace --exclude feedparser-rs-py -- -D warnings` — clean
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `test_rss20_custom_dc_prefix` — Dublin Core with `xmlns:dublin` prefix parses correctly
- [ ] `test_rss20_custom_itunes_prefix` — iTunes with `xmlns:it` prefix parses correctly
- [ ] `test_is_itunes_tag_security` — path-traversal local names rejected