### PR TITLE
fix(core): podcast:season and podcast:episode read text content per spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python binding: `Cloud.registerprocedure` (no underscore) now correctly exposed as `registerprocedure` to match Python feedparser API (#335)
 - Node.js binding: `cloud.registerprocedure` (no underscore) now correctly exposed as `registerprocedure` instead of `registerProcedure` for Python feedparser compatibility (#335)
 - Namespace extension parsers (Dublin Core, Media RSS, iTunes) now resolve namespace URIs instead of matching only hardcoded prefixes; feeds using non-standard prefixes (e.g. `xmlns:dublin="http://purl.org/dc/elements/1.1/"`) are correctly parsed (#334)
+- `podcast:season` and `podcast:episode` now read element text content as primary value per Podcast 2.0 spec, with `number` attribute as fallback; fixes feeds like TWiT that use text content (#348)
 
 ## [0.5.1] - 2026-03-24
 

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -1619,25 +1619,43 @@ fn parse_item_podcast(
         }
         Ok(true)
     } else if tag.starts_with(b"podcast:season") {
-        if let Some(number) = find_attribute(attrs, b"number") {
-            let podcast = entry
+        let value = if is_empty {
+            find_attribute(attrs, b"number")
+                .map(|n| truncate_to_length(n, limits.max_attribute_length))
+        } else {
+            let text = read_text_str(reader, buf, limits)?;
+            if text.is_empty() {
+                find_attribute(attrs, b"number")
+                    .map(|n| truncate_to_length(n, limits.max_attribute_length))
+            } else {
+                Some(text)
+            }
+        };
+        if let Some(v) = value {
+            entry
                 .podcast
-                .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()));
-            podcast.season = Some(truncate_to_length(number, limits.max_attribute_length));
-        }
-        if !is_empty {
-            skip_element(reader, buf, limits, depth)?;
+                .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()))
+                .season = Some(v);
         }
         Ok(true)
     } else if tag.starts_with(b"podcast:episode") {
-        if let Some(number) = find_attribute(attrs, b"number") {
-            let podcast = entry
+        let value = if is_empty {
+            find_attribute(attrs, b"number")
+                .map(|n| truncate_to_length(n, limits.max_attribute_length))
+        } else {
+            let text = read_text_str(reader, buf, limits)?;
+            if text.is_empty() {
+                find_attribute(attrs, b"number")
+                    .map(|n| truncate_to_length(n, limits.max_attribute_length))
+            } else {
+                Some(text)
+            }
+        };
+        if let Some(v) = value {
+            entry
                 .podcast
-                .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()));
-            podcast.episode = Some(truncate_to_length(number, limits.max_attribute_length));
-        }
-        if !is_empty {
-            skip_element(reader, buf, limits, depth)?;
+                .get_or_insert_with(|| Box::new(PodcastEntryMeta::default()))
+                .episode = Some(v);
         }
         Ok(true)
     } else {
@@ -3676,8 +3694,9 @@ mod tests {
             .podcast
             .as_deref()
             .expect("entry.podcast must be Some");
-        assert_eq!(podcast.season.as_deref(), Some("3"));
-        assert_eq!(podcast.episode.as_deref(), Some("42"));
+        // text content takes priority over number attribute
+        assert_eq!(podcast.season.as_deref(), Some("Season Three"));
+        assert_eq!(podcast.episode.as_deref(), Some("Bonus"));
     }
 
     #[test]
@@ -3696,13 +3715,13 @@ mod tests {
 
         let feed = parse_rss20(xml).unwrap();
         let entry = &feed.entries[0];
-        // podcast is Some because transcript forces it; season/episode must be None (no number attr)
+        // text content is used when number attribute is absent
         let podcast = entry
             .podcast
             .as_deref()
             .expect("entry.podcast must be Some due to transcript element");
-        assert!(podcast.season.is_none());
-        assert!(podcast.episode.is_none());
+        assert_eq!(podcast.season.as_deref(), Some("3"));
+        assert_eq!(podcast.episode.as_deref(), Some("42"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Per [Podcast 2.0 spec](https://podcastindex.org/namespace/1.0), `podcast:episode` and `podcast:season` values are text content of the element, not a `number` attribute
- Parser now reads text content as primary value; falls back to `number` attribute for backward compatibility
- Fixes TWiT and other feeds using standard text-content form: `<podcast:episode>1077</podcast:episode>`

## Test plan

- [x] `test_podcast_season_episode_parsed` — text content takes priority over `number` attribute
- [x] `test_podcast_season_episode_no_number_attr` — text content works when no `number` attribute present
- [x] `test_podcast_season_episode_missing` — no value when element is empty
- [x] `test_podcast_season_episode_bozo` — malformed feed sets bozo without panic
- [x] Full workspace test suite passes (1028 tests)

Closes #348