### PR TITLE
fix(core): Atom author inheritance and null byte stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node.js binding: `cloud.registerprocedure` (no underscore) now correctly exposed as `registerprocedure` instead of `registerProcedure` for Python feedparser compatibility (#335)
 - Namespace extension parsers (Dublin Core, Media RSS, iTunes) now resolve namespace URIs instead of matching only hardcoded prefixes; feeds using non-standard prefixes (e.g. `xmlns:dublin="http://purl.org/dc/elements/1.1/"`) are correctly parsed (#334)
 - `podcast:season` and `podcast:episode` now read element text content as primary value per Podcast 2.0 spec, with `number` attribute as fallback; fixes feeds like TWiT that use text content (#348)
+- Atom entries with no `<author>` element now inherit feed-level authors per RFC 4287 §4.1.2; previously entries were returned with empty authors when the feed defined authors (#353)
+- Null bytes (U+0000) in XML text content are now silently stripped from all parsed text fields (titles, descriptions, authors, etc.) per XML 1.0 §2.2 (#352)
 
 ## [0.5.1] - 2026-03-24
 

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -136,6 +136,19 @@ pub fn parse_atom10_with_limits(data: &[u8], limits: ParserLimits) -> Result<Par
         buf.clear();
     }
 
+    // RFC 4287 §4.1.2: entries with no authors inherit feed-level authors.
+    if !feed.feed.authors.is_empty() {
+        let feed_authors = feed.feed.authors.clone();
+        for entry in &mut feed.entries {
+            if entry.authors.is_empty() {
+                entry.authors.clone_from(&feed_authors);
+                if entry.author.is_none() {
+                    entry.author.clone_from(&feed.feed.author);
+                }
+            }
+        }
+    }
+
     Ok(feed)
 }
 
@@ -3572,5 +3585,102 @@ mod tests {
                 .is_none(),
             "entry title under xml:lang=\"\" entry should have None language"
         );
+    }
+
+    #[test]
+    fn test_atom_author_inheritance_from_feed() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <author><name>Feed Author</name><email>feed@example.com</email></author>
+            <entry>
+                <title>Entry without author</title>
+                <id>entry1</id>
+                <updated>2024-01-01T00:00:00Z</updated>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        assert_eq!(feed.entries.len(), 1);
+        assert_eq!(feed.entries[0].authors.len(), 1);
+        assert_eq!(
+            feed.entries[0].authors[0].name.as_deref(),
+            Some("Feed Author")
+        );
+        // author is flat_string() which may include email
+        assert!(
+            feed.entries[0]
+                .author
+                .as_deref()
+                .unwrap_or("")
+                .contains("Feed Author")
+        );
+    }
+
+    #[test]
+    fn test_atom_entry_author_takes_precedence() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <author><name>Feed Author</name></author>
+            <entry>
+                <title>Entry with own author</title>
+                <id>entry1</id>
+                <updated>2024-01-01T00:00:00Z</updated>
+                <author><name>Entry Author</name></author>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        assert_eq!(feed.entries[0].authors.len(), 1);
+        assert_eq!(
+            feed.entries[0].authors[0].name.as_deref(),
+            Some("Entry Author")
+        );
+        assert_eq!(feed.entries[0].author.as_deref(), Some("Entry Author"));
+    }
+
+    #[test]
+    fn test_atom_author_inheritance_mixed_entries() {
+        let xml = br#"<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Test</title>
+            <author><name>Feed Author</name></author>
+            <entry>
+                <title>Entry with own author</title>
+                <id>entry1</id>
+                <updated>2024-01-01T00:00:00Z</updated>
+                <author><name>Entry Author</name></author>
+            </entry>
+            <entry>
+                <title>Entry without author</title>
+                <id>entry2</id>
+                <updated>2024-01-02T00:00:00Z</updated>
+            </entry>
+        </feed>"#;
+
+        let feed = parse_atom10(xml).unwrap();
+        assert!(!feed.bozo);
+        assert_eq!(feed.entries[0].author.as_deref(), Some("Entry Author"));
+        assert_eq!(feed.entries[1].author.as_deref(), Some("Feed Author"));
+    }
+
+    #[test]
+    fn test_atom_null_bytes_stripped_from_title() {
+        let xml = b"<?xml version=\"1.0\"?>\
+        <feed xmlns=\"http://www.w3.org/2005/Atom\">\
+            <title>Hello\x00World</title>\
+            <entry>\
+                <title>Entry\x00Title</title>\
+                <id>e1</id>\
+                <updated>2024-01-01T00:00:00Z</updated>\
+            </entry>\
+        </feed>";
+
+        let feed = parse_atom10(xml).unwrap();
+        assert_eq!(feed.feed.title.as_deref(), Some("HelloWorld"));
+        assert_eq!(feed.entries[0].title.as_deref(), Some("EntryTitle"));
     }
 }

--- a/crates/feedparser-rs-core/src/parser/common.rs
+++ b/crates/feedparser-rs-core/src/parser/common.rs
@@ -584,7 +584,7 @@ pub fn read_text(
         buf.clear();
     }
 
-    let trimmed = text.trim().to_string();
+    let trimmed = text.trim().replace('\0', "");
     Ok((trimmed, had_bozo))
 }
 
@@ -1443,5 +1443,25 @@ mod tests {
         ));
         // Unprefixed path traversal also rejected (no colon → direct match, but value differs)
         assert!(!is_itunes_tag(b"../../etc/passwd", b"author", &empty));
+    }
+
+    #[test]
+    fn test_read_text_strips_null_bytes() {
+        let xml = b"<title>Hello\x00World</title>";
+        let mut reader = Reader::from_reader(&xml[..]);
+        let mut buf = Vec::new();
+        let limits = ParserLimits::default();
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(_)) => break,
+                Ok(Event::Eof) => panic!("Unexpected EOF"),
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        let (text, _bozo) = read_text(&mut reader, &mut buf, &limits).unwrap();
+        assert_eq!(text, "HelloWorld");
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #353: Atom `<entry>` elements with no `<author>` now inherit feed-level authors per RFC 4287 §4.1.2
- Fixes #352: Null bytes (U+0000) are silently stripped from all parsed text fields per XML 1.0 §2.2

## Changes

### `crates/feedparser-rs-core/src/parser/atom.rs`
- Post-processing loop after the main event loop: for each entry with empty `authors`, copies feed-level authors (matching Python feedparser behavior)
- 3 regression tests: basic inheritance, entry-level author takes precedence, mixed entries

### `crates/feedparser-rs-core/src/parser/common.rs`
- `read_text()`: added `.replace('\0', "")` to strip null bytes from all text fields
- 1 unit test for the stripping mechanism
- 1 integration test (Atom feed with null bytes end-to-end)

## Test plan

- [ ] All 1034 tests pass (`cargo nextest run --all-features --workspace --exclude feedparser-rs-py`)
- [ ] Atom entries without `<author>` inherit feed-level authors
- [ ] Atom entries with own `<author>` are not affected
- [ ] Null bytes stripped from titles, descriptions, and all other text fields
- [ ] CHANGELOG.md [Unreleased] updated