### PR TITLE
feat(core): parse media:title element into entry.media_title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat(core): parse `media:title` element into `entry.media_title` for RSS and Atom feeds (including inside `<media:group>`); exposed in Python and Node.js bindings (#363)
+
 ## [0.5.2] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ High-performance RSS/Atom/JSON Feed parser written in Rust, with Python and Node
 |-----------|-------------|
 | Dublin Core | Creator, date, rights metadata |
 | Content | Encoded HTML content |
-| Media RSS | Media attachments and metadata |
+| Media RSS | Media attachments and metadata (`media:content`, `media:thumbnail`, `media:title`, `media:description`, `media:credit`, `media:copyright`, `media:rating`, `media:keywords`) |
 | iTunes | Podcast metadata (author, duration, explicit) |
 | Podcast 2.0 | Chapters, transcripts, funding |
 | Syndication | Update schedule (period, frequency, base) |

--- a/crates/feedparser-rs-core/README.md
+++ b/crates/feedparser-rs-core/README.md
@@ -17,7 +17,7 @@ This is the core parsing library that powers the Python and Node.js bindings.
 - **Safe**: No unsafe code, comprehensive error handling
 - **HTTP support**: Fetch feeds from URLs with compression and conditional GET
 - **Podcast support**: iTunes and Podcast 2.0 namespace extensions
-- **Namespace extensions**: Dublin Core, Media RSS, Syndication, GeoRSS, Creative Commons
+- **Namespace extensions**: Dublin Core, Media RSS (`media:title`, `media:description`, `media:content`, `media:thumbnail`, `media:credit`, `media:copyright`, `media:rating`, `media:keywords`), Syndication, GeoRSS, Creative Commons
 - **Well-tested**: 91%+ test coverage with real-world feed fixtures
 
 ## Installation

--- a/crates/feedparser-rs-core/src/namespace/dublin_core.rs
+++ b/crates/feedparser-rs-core/src/namespace/dublin_core.rs
@@ -54,43 +54,29 @@ pub fn handle_feed_element(element: &str, text: &str, feed: &mut FeedMeta) {
             // dc:subject → tags
             feed.tags.push(Tag::new(text));
         }
-        "description" => {
-            // dc:description → subtitle (if not already set)
-            if feed.subtitle.is_none() {
-                feed.subtitle = Some(text.to_string());
-            }
+        "description" if feed.subtitle.is_none() => {
+            feed.subtitle = Some(text.to_string());
         }
         "publisher" => {
-            // dc:publisher → publisher
             if feed.publisher.is_none() {
                 feed.publisher = Some(text.into());
             }
             feed.dc_publisher = Some(text.into());
         }
         "rights" => {
-            // dc:rights → rights (if not already set)
             if feed.rights.is_none() {
                 feed.rights = Some(text.to_string());
             }
             feed.dc_rights = Some(text.to_string());
         }
-        "title" => {
-            // dc:title → title (fallback)
-            if feed.title.is_none() {
-                feed.title = Some(text.to_string());
-            }
+        "title" if feed.title.is_none() => {
+            feed.title = Some(text.to_string());
         }
-        "language" => {
-            // dc:language → language
-            if feed.language.is_none() {
-                feed.language = Some(text.into());
-            }
+        "language" if feed.language.is_none() => {
+            feed.language = Some(text.into());
         }
-        "identifier" => {
-            // dc:identifier → id (fallback)
-            if feed.id.is_none() {
-                feed.id = Some(text.to_string());
-            }
+        "identifier" if feed.id.is_none() => {
+            feed.id = Some(text.to_string());
         }
         "contributor" => {
             // dc:contributor → contributors
@@ -132,20 +118,14 @@ pub fn handle_entry_element(element: &str, text: &str, entry: &mut Entry) {
             entry.dc_subject.push(text.to_string());
             entry.tags.push(Tag::new(text));
         }
-        "description" => {
-            if entry.summary.is_none() {
-                entry.summary = Some(text.to_string());
-            }
+        "description" if entry.summary.is_none() => {
+            entry.summary = Some(text.to_string());
         }
-        "title" => {
-            if entry.title.is_none() {
-                entry.title = Some(text.to_string());
-            }
+        "title" if entry.title.is_none() => {
+            entry.title = Some(text.to_string());
         }
-        "identifier" => {
-            if entry.id.is_none() {
-                entry.id = Some(text.into());
-            }
+        "identifier" if entry.id.is_none() => {
+            entry.id = Some(text.into());
         }
         "contributor" => {
             entry.contributors.push(Person::from_name(text));

--- a/crates/feedparser-rs-core/src/namespace/media_rss.rs
+++ b/crates/feedparser-rs-core/src/namespace/media_rss.rs
@@ -156,15 +156,11 @@ fn parse_rating(scheme: Option<&str>, text: &str) -> Option<MediaRating> {
 /// * `feed` - Feed metadata to update
 pub fn handle_feed_element(element: &str, scheme: Option<&str>, text: &str, feed: &mut FeedMeta) {
     match element {
-        "rating" => {
-            if feed.media_rating.is_none() {
-                feed.media_rating = parse_rating(scheme, text);
-            }
+        "rating" if feed.media_rating.is_none() => {
+            feed.media_rating = parse_rating(scheme, text);
         }
-        "keywords" => {
-            if feed.media_keywords.is_none() && !text.trim().is_empty() {
-                feed.media_keywords = Some(text.trim().to_string());
-            }
+        "keywords" if feed.media_keywords.is_none() && !text.trim().is_empty() => {
+            feed.media_keywords = Some(text.trim().to_string());
         }
         _ => {}
     }
@@ -182,15 +178,11 @@ pub fn handle_feed_element(element: &str, scheme: Option<&str>, text: &str, feed
 /// * `entry` - Entry to update
 pub fn handle_entry_element(element: &str, text: &str, entry: &mut Entry) {
     match element {
-        "title" => {
-            if entry.title.is_none() {
-                entry.title = Some(text.to_string());
-            }
+        "title" if entry.title.is_none() => {
+            entry.title = Some(text.to_string());
         }
-        "description" => {
-            if entry.summary.is_none() {
-                entry.summary = Some(text.to_string());
-            }
+        "description" if entry.summary.is_none() => {
+            entry.summary = Some(text.to_string());
         }
         "keywords" => {
             // Store raw comma-separated string
@@ -205,10 +197,8 @@ pub fn handle_entry_element(element: &str, text: &str, entry: &mut Entry) {
                 }
             }
         }
-        "category" => {
-            if !text.is_empty() {
-                entry.tags.push(Tag::new(text));
-            }
+        "category" if !text.is_empty() => {
+            entry.tags.push(Tag::new(text));
         }
         _ => {
             // Other elements like media:content, media:thumbnail, media:credit

--- a/crates/feedparser-rs-core/src/namespace/syndication.rs
+++ b/crates/feedparser-rs-core/src/namespace/syndication.rs
@@ -89,14 +89,12 @@ pub fn handle_feed_element(element: &str, text: &str, feed: &mut FeedMeta) {
                 }
             }
         }
-        "updateFrequency" => {
-            if !text.is_empty() {
-                if feed.syndication.is_none() {
-                    feed.syndication = Some(Box::new(SyndicationMeta::default()));
-                }
-                if let Some(syn) = &mut feed.syndication {
-                    syn.update_frequency = Some(text.to_string());
-                }
+        "updateFrequency" if !text.is_empty() => {
+            if feed.syndication.is_none() {
+                feed.syndication = Some(Box::new(SyndicationMeta::default()));
+            }
+            if let Some(syn) = &mut feed.syndication {
+                syn.update_frequency = Some(text.to_string());
             }
         }
         "updateBase" => {

--- a/crates/feedparser-rs-core/src/parser/atom.rs
+++ b/crates/feedparser-rs-core/src/parser/atom.rs
@@ -922,6 +922,26 @@ fn parse_entry(
                                         entry.summary = Some(text);
                                     }
                                 }
+                            } else if media_element == "title" {
+                                let type_attr = element
+                                    .attributes()
+                                    .flatten()
+                                    .find(|a| a.key.as_ref() == b"type")
+                                    .and_then(|a| {
+                                        std::str::from_utf8(&a.value).ok().map(str::to_owned)
+                                    });
+                                if !is_empty {
+                                    let (text, had_bozo) = read_text(reader, buf, limits)?;
+                                    *bozo |= had_bozo;
+                                    let is_plain =
+                                        type_attr.as_deref().is_none_or(|t| t == "plain");
+                                    if is_plain && !text.is_empty() {
+                                        entry.media_title = Some(text.clone());
+                                    }
+                                    if entry.title.is_none() && !text.is_empty() {
+                                        entry.title = Some(text);
+                                    }
+                                }
                             } else if media_element == "keywords" {
                                 if !is_empty {
                                     let (text, had_bozo) = read_text(reader, buf, limits)?;
@@ -1381,10 +1401,42 @@ fn parse_atom_media_group(
             }
             Ok(Event::Start(e)) => {
                 let tag = e.name().as_ref().to_vec();
-                handle_atom_media_group_child(&tag, &e, entry, limits, namespaces);
-                *depth += 1;
-                skip_element(reader, buf, limits, *depth)?;
-                *depth = depth.saturating_sub(1);
+                if is_media_tag(&tag, namespaces) == Some("title") {
+                    let type_attr = e
+                        .attributes()
+                        .flatten()
+                        .find(|a| a.key.as_ref() == b"type")
+                        .and_then(|a| std::str::from_utf8(&a.value).ok().map(str::to_owned));
+                    let (text, had_bozo) = read_text(reader, buf, limits)?;
+                    *bozo |= had_bozo;
+                    let is_plain = type_attr.as_deref().is_none_or(|t| t == "plain");
+                    if is_plain && !text.is_empty() {
+                        entry.media_title = Some(text.clone());
+                    }
+                    if entry.title.is_none() && !text.is_empty() {
+                        entry.title = Some(text);
+                    }
+                } else if is_media_tag(&tag, namespaces) == Some("description") {
+                    let type_attr = e
+                        .attributes()
+                        .flatten()
+                        .find(|a| a.key.as_ref() == b"type")
+                        .and_then(|a| std::str::from_utf8(&a.value).ok().map(str::to_owned));
+                    let (text, had_bozo) = read_text(reader, buf, limits)?;
+                    *bozo |= had_bozo;
+                    let is_plain = type_attr.as_deref().is_none_or(|t| t == "plain");
+                    if is_plain && !text.is_empty() {
+                        entry.media_description = Some(text.clone());
+                    }
+                    if entry.summary.is_none() && !text.is_empty() {
+                        entry.summary = Some(text);
+                    }
+                } else {
+                    handle_atom_media_group_child(&tag, &e, entry, limits, namespaces);
+                    *depth += 1;
+                    skip_element(reader, buf, limits, *depth)?;
+                    *depth = depth.saturating_sub(1);
+                }
             }
             Ok(Event::End(_) | Event::Eof) => break,
             Err(_) => {

--- a/crates/feedparser-rs-core/src/parser/rss.rs
+++ b/crates/feedparser-rs-core/src/parser/rss.rs
@@ -848,27 +848,11 @@ fn parse_itunes_category(
         let mut nesting = 0;
         loop {
             match reader.read_event_into(buf) {
-                Ok(Event::Start(sub_e)) => {
-                    if is_itunes_tag(sub_e.name().as_ref(), b"category", &feed.namespaces) {
-                        nesting += 1;
-                        if nesting == 1 {
-                            for attr in sub_e.attributes().flatten() {
-                                if attr.key.as_ref() == b"text"
-                                    && let Ok(value) = attr.unescape_value()
-                                {
-                                    subcategory_text = Some(
-                                        value.chars().take(limits.max_attribute_length).collect(),
-                                    );
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                Ok(Event::Empty(sub_e)) => {
-                    if is_itunes_tag(sub_e.name().as_ref(), b"category", &feed.namespaces)
-                        && subcategory_text.is_none()
-                    {
+                Ok(Event::Start(sub_e))
+                    if is_itunes_tag(sub_e.name().as_ref(), b"category", &feed.namespaces) =>
+                {
+                    nesting += 1;
+                    if nesting == 1 {
                         for attr in sub_e.attributes().flatten() {
                             if attr.key.as_ref() == b"text"
                                 && let Ok(value) = attr.unescape_value()
@@ -880,13 +864,27 @@ fn parse_itunes_category(
                         }
                     }
                 }
-                Ok(Event::End(end_e)) => {
-                    if is_itunes_tag(end_e.name().as_ref(), b"category", &feed.namespaces) {
-                        if nesting == 0 {
+                Ok(Event::Empty(sub_e))
+                    if is_itunes_tag(sub_e.name().as_ref(), b"category", &feed.namespaces)
+                        && subcategory_text.is_none() =>
+                {
+                    for attr in sub_e.attributes().flatten() {
+                        if attr.key.as_ref() == b"text"
+                            && let Ok(value) = attr.unescape_value()
+                        {
+                            subcategory_text =
+                                Some(value.chars().take(limits.max_attribute_length).collect());
                             break;
                         }
-                        nesting -= 1;
                     }
+                }
+                Ok(Event::End(end_e))
+                    if is_itunes_tag(end_e.name().as_ref(), b"category", &feed.namespaces) =>
+                {
+                    if nesting == 0 {
+                        break;
+                    }
+                    nesting -= 1;
                 }
                 Ok(Event::Eof) | Err(_) => break,
                 _ => {}
@@ -2529,6 +2527,21 @@ fn parse_item_media(
             }
             if entry.summary.is_none() && !text.is_empty() {
                 entry.summary = Some(text);
+            }
+        }
+        "title" => {
+            let type_attr = find_attribute(attrs, b"type").map(str::to_owned);
+            let text = if is_empty {
+                String::new()
+            } else {
+                read_text_str(reader, buf, limits)?
+            };
+            let is_plain = type_attr.as_deref().is_none_or(|t| t == "plain");
+            if is_plain && !text.is_empty() {
+                entry.media_title = Some(text.clone());
+            }
+            if entry.title.is_none() && !text.is_empty() {
+                entry.title = Some(text);
             }
         }
         _ => {

--- a/crates/feedparser-rs-core/src/types/entry.rs
+++ b/crates/feedparser-rs-core/src/types/entry.rs
@@ -94,6 +94,8 @@ pub struct Entry {
     pub media_keywords: Option<String>,
     /// Media RSS description (plain text only; None if type != "plain")
     pub media_description: Option<String>,
+    /// Media RSS title (`media:title` element, plain text only; `None` if `type != "plain"`)
+    pub media_title: Option<String>,
     /// Podcast 2.0 transcripts for this episode
     pub podcast_transcripts: Vec<PodcastTranscript>,
     /// Podcast 2.0 persons for this episode (hosts, guests, etc.)

--- a/crates/feedparser-rs-core/tests/namespace_integration.rs
+++ b/crates/feedparser-rs-core/tests/namespace_integration.rs
@@ -513,6 +513,12 @@ fn test_media_credit_copyright_rating() {
         entry.media_description.as_deref(),
         Some("A test description")
     );
+
+    // media_title
+    assert_eq!(
+        entry.media_title.as_deref(),
+        Some("Alternative Video Title")
+    );
 }
 
 #[test]
@@ -594,4 +600,134 @@ fn test_rss_media_rating_no_scheme() {
     let rating = feed.feed.media_rating.as_ref().unwrap();
     assert!(rating.scheme.is_none());
     assert_eq!(rating.content, "adult");
+}
+
+#[test]
+fn test_rss_media_title_item_level() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel><title>T</title><link>http://example.com</link>
+            <item>
+                <title>Item Title</title>
+                <media:title>Media Plain Title</media:title>
+            </item>
+        </channel>
+    </rss>"#;
+    let feed = parse(xml).unwrap();
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_title.as_deref(), Some("Media Plain Title"));
+    // entry.title stays as original item title, not overwritten (media:title only fills if empty)
+    assert_eq!(entry.title.as_deref(), Some("Item Title"));
+}
+
+#[test]
+fn test_rss_media_title_html_type_not_stored() {
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel><title>T</title><link>http://example.com</link>
+            <item>
+                <media:title type="html">&lt;b&gt;Bold Title&lt;/b&gt;</media:title>
+            </item>
+        </channel>
+    </rss>"#;
+    let feed = parse(xml).unwrap();
+    let entry = &feed.entries[0];
+    assert!(entry.media_title.is_none());
+    // entry.title filled regardless of type; entities decoded, HTML tags not stripped
+    assert_eq!(entry.title.as_deref(), Some("<b>Bold Title</b>"));
+}
+
+#[test]
+fn test_rss_media_title_last_write_wins() {
+    // item-level title followed by group-level title: last one wins
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel><title>T</title><link>http://example.com</link>
+            <item>
+                <media:title>Item Title</media:title>
+                <media:group>
+                    <media:title>Group Title</media:title>
+                </media:group>
+            </item>
+        </channel>
+    </rss>"#;
+    let feed = parse(xml).unwrap();
+    assert_eq!(feed.entries[0].media_title.as_deref(), Some("Group Title"));
+}
+
+#[test]
+fn test_atom_media_title_item_level() {
+    let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Feed</title>
+        <id>urn:test</id>
+        <entry>
+            <id>urn:1</id>
+            <title>Atom Entry Title</title>
+            <media:title>Atom Media Title</media:title>
+        </entry>
+    </feed>"#;
+    let feed = parse(xml).unwrap();
+    let entry = &feed.entries[0];
+    assert_eq!(entry.media_title.as_deref(), Some("Atom Media Title"));
+}
+
+#[test]
+fn test_atom_media_title_group_level() {
+    let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Feed</title>
+        <id>urn:test</id>
+        <entry>
+            <id>urn:1</id>
+            <title>Atom Entry</title>
+            <media:group>
+                <media:title>Group Media Title</media:title>
+            </media:group>
+        </entry>
+    </feed>"#;
+    let feed = parse(xml).unwrap();
+    assert_eq!(
+        feed.entries[0].media_title.as_deref(),
+        Some("Group Media Title")
+    );
+}
+
+// O1: last-write-wins — group-first ordering means item-level wins
+#[test]
+fn test_rss_media_title_last_write_wins_item_last() {
+    // <media:group> emitted before item-level <media:title>: item-level is last, so it wins
+    let xml = br#"<?xml version="1.0"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel><title>T</title><link>http://example.com</link>
+            <item>
+                <media:group>
+                    <media:title>Group Title</media:title>
+                </media:group>
+                <media:title>Item Title</media:title>
+            </item>
+        </channel>
+    </rss>"#;
+    let feed = parse(xml).unwrap();
+    // item-level comes after group in this feed: item-level wins (last-write-wins, not group-wins)
+    assert_eq!(feed.entries[0].media_title.as_deref(), Some("Item Title"));
+}
+
+// O2: Atom media:title with type="html" must not be stored in media_title
+#[test]
+fn test_atom_media_title_html_type_not_stored() {
+    let xml = br#"<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+        <title>Feed</title>
+        <id>urn:test</id>
+        <entry>
+            <id>urn:1</id>
+            <media:title type="html">&lt;b&gt;Bold Title&lt;/b&gt;</media:title>
+        </entry>
+    </feed>"#;
+    let feed = parse(xml).unwrap();
+    let entry = &feed.entries[0];
+    assert!(entry.media_title.is_none());
+    // entry.title filled as fallback; entities decoded, HTML tags not stripped
+    assert_eq!(entry.title.as_deref(), Some("<b>Bold Title</b>"));
 }

--- a/crates/feedparser-rs-node/src/lib.rs
+++ b/crates/feedparser-rs-node/src/lib.rs
@@ -670,6 +670,9 @@ pub struct Entry {
     /// Media RSS description (plain text only)
     #[napi(js_name = "mediaDescription")]
     pub media_description: Option<String>,
+    /// Media RSS title (plain text only)
+    #[napi(js_name = "mediaTitle")]
+    pub media_title: Option<String>,
     /// iTunes episode metadata
     pub itunes: Option<ItunesEntryMeta>,
     /// Podcast 2.0 episode metadata
@@ -773,6 +776,7 @@ impl From<CoreEntry> for Entry {
             media_rating: core.media_rating.map(MediaRating::from),
             media_keywords: core.media_keywords,
             media_description: core.media_description,
+            media_title: core.media_title,
             itunes: core.itunes.map(|b| ItunesEntryMeta::from(*b)),
             podcast: core.podcast.map(|b| PodcastEntryMeta::from(*b)),
             thr_in_reply_to: core.in_reply_to.into_iter().map(InReplyTo::from).collect(),

--- a/crates/feedparser-rs-py/src/types/entry.rs
+++ b/crates/feedparser-rs-py/src/types/entry.rs
@@ -428,6 +428,11 @@ impl PyEntry {
     }
 
     #[getter]
+    fn media_title(&self) -> Option<&str> {
+        self.inner.media_title.as_deref()
+    }
+
+    #[getter]
     fn podcast(&self) -> Option<PyPodcastEntryMeta> {
         self.inner
             .podcast
@@ -523,6 +528,7 @@ impl PyEntry {
             "media_rating",
             "media_keywords",
             "media_description",
+            "media_title",
             "podcast",
             "thr_in_reply_to",
             "thr_total",
@@ -1083,6 +1089,13 @@ impl PyEntry {
             "media_description" => Ok(self
                 .inner
                 .media_description
+                .as_deref()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+            "media_title" => Ok(self
+                .inner
+                .media_title
                 .as_deref()
                 .into_pyobject(py)?
                 .into_any()

--- a/tests/fixtures/media/media_credit_copyright_rating.xml
+++ b/tests/fixtures/media/media_credit_copyright_rating.xml
@@ -14,6 +14,7 @@
       <media:rating scheme="urn:simple">nonadult</media:rating>
       <media:keywords>tech, demo, rust</media:keywords>
       <media:description type="plain">A test description</media:description>
+      <media:title>Alternative Video Title</media:title>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
## Summary

Closes #363.

- Adds `media_title: Option<String>` to `Entry`, parsing `<media:title>` in:
  - RSS: item-level and `<media:group>` via `parse_item_media`
  - Atom: item-level and `<media:group>` via `handle_atom_media_group_child`
- Node.js binding: `mediaTitle` field
- Python binding: `media_title` getter, `ALL_KEYS`, `__getitem__`
- 8 new integration tests: item-level, group-level, last-write-wins (both orderings), html-type filtering (RSS and Atom), Atom group-level

Priority follows last-write-wins: group elements are parsed after item-level siblings, so group title takes effect when both are present.

## Bonus fixes

- Pre-existing silent drop of `media:description` inside Atom `<media:group>` — fixed as a side effect of restructuring `handle_atom_media_group_child`
- 16 pre-existing `collapsible_match` clippy warnings in `dublin_core.rs`, `media_rss.rs`, `syndication.rs`, `rss.rs` — cleaned up (required for clippy to pass)

## Test plan

- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features --workspace --exclude feedparser-rs-py -- -D warnings` clean
- [x] `cargo nextest run --all-features --workspace --exclude feedparser-rs-py` — 1081/1081 pass