### PR TITLE
fix: update rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Bumps `rustls-webpki` from 0.103.12 to 0.103.13 to address RUSTSEC-2026-0104.

## Advisory

A reachable panic existed in certificate revocation list parsing via
`BorrowedCertRevocationList::from_der` / `OwnedCertRevocationList::from_der`.
Triggered by a syntactically valid empty BIT STRING in the `onlySomeReasons`
element of an `IssuingDistributionPoint` CRL extension, before signature
verification. Applications not using CRLs are not affected.

Dependency chain: `reqwest` → `hyper-rustls` → `rustls` → `rustls-webpki`

## Fix

`cargo update -p rustls-webpki` — updates lock file only, no manifest changes.