### PR TITLE
release: v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-04-24
+
 ### Added
 
 - feat(core): parse `media:title` element into `entry.media_title` for RSS and Atom feeds (including inside `<media:group>`); exposed in Python and Node.js bindings (#363)
+
+### Security
+
+- Update `rustls-webpki` to 0.103.13 to address RUSTSEC-2026-0104
 
 ## [0.5.2] - 2026-04-06
 
@@ -474,7 +480,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage
 - Documentation with examples
 
-[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/bug-ops/feedparser-rs/compare/v0.4.8...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "feedparser-rs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ammonia",
  "chrono",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-node"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "feedparser-rs",
  "napi",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-py"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "feedparser-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["bug-ops"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs = "0.5.0"
+feedparser-rs = "0.5.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/feedparser-rs-core/README.md
+++ b/crates/feedparser-rs-core/README.md
@@ -30,7 +30,7 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs = "0.4"
+feedparser-rs = "0.5"
 ```
 
 > [!IMPORTANT]

--- a/crates/feedparser-rs-node/README.md
+++ b/crates/feedparser-rs-node/README.md
@@ -165,6 +165,7 @@ interface Entry {
   authors: Person[];
   tags: Tag[];
   enclosures: Enclosure[];
+  media_title?: string;
 }
 ```
 

--- a/crates/feedparser-rs-node/package.json
+++ b/crates/feedparser-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedparser-rs",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "High-performance RSS/Atom/JSON Feed parser for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/feedparser-rs-py/pyproject.toml
+++ b/crates/feedparser-rs-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feedparser-rs"
-version = "0.5.2"
+version = "0.5.3"
 description = "High-performance RSS/Atom/JSON Feed parser with feedparser-compatible API"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump version from 0.5.2 to 0.5.3
- Update CHANGELOG.md with release notes
- Update version in `pyproject.toml` and `package.json`

## Changes in this release

- feat(core): parse `media:title` element into `entry.media_title` for RSS and Atom feeds (including inside `<media:group>`); exposed in Python and Node.js bindings (#363)
- Security: update `rustls-webpki` to 0.103.13 (RUSTSEC-2026-0104)

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] All CI checks pass
- [ ] Ready for tagging after merge