### PR TITLE
release: v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-26
+
+### Changed
+
+- Bump `napi` to 3.9.0 in the Node.js bindings (#387)
+- Bump `quick-xml` from 0.39.4 to 0.40.1 (#388)
+- Bump `serde_json` patch version (#389)
+- Bump `napi-build` to 2.3 and `napi-derive` to 3.5.6 in the Node.js bindings (#386)
+- Bump `quick-xml` patch version (#385)
+- Bump `@biomejs/biome` (Node.js dev tooling) (#381, #382, #384)
+- Various transitive dependency patch updates via Dependabot (#383)
+
 ## [0.5.3] - 2026-04-24
 
 ### Added
@@ -480,7 +492,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage
 - Documentation with examples
 
-[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.0...v0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "feedparser-rs"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "ammonia",
  "chrono",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-node"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "feedparser-rs",
  "napi",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-py"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "chrono",
  "feedparser-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["bug-ops"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs = "0.5.3"
+feedparser-rs = "0.5.4"
 ```
 
 > [!IMPORTANT]

--- a/crates/feedparser-rs-node/package-lock.json
+++ b/crates/feedparser-rs-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedparser-rs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedparser-rs",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",

--- a/crates/feedparser-rs-node/package.json
+++ b/crates/feedparser-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedparser-rs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "High-performance RSS/Atom/JSON Feed parser for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/feedparser-rs-py/pyproject.toml
+++ b/crates/feedparser-rs-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feedparser-rs"
-version = "0.5.3"
+version = "0.5.4"
 description = "High-performance RSS/Atom/JSON Feed parser with feedparser-compatible API"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump version from 0.5.3 to 0.5.4
- Update CHANGELOG.md with release notes for v0.5.4
- Update version references in README.md and pyproject.toml

## Changes

All changes in this release are dependency updates:

- `napi` 3.8 → 3.9.0 (#387)
- `quick-xml` 0.39.4 → 0.40.1 (#388)
- `serde_json` patch update (#389)
- `napi-build` → 2.3, `napi-derive` → 3.5.6 (#386)
- `quick-xml` patch (#385)
- `@biomejs/biome` dev tooling (#381, #382, #384)
- Transitive dependency patch updates (#383)

## Checklist

- [x] Version updated in all manifests (workspace Cargo.toml, pyproject.toml)
- [x] CHANGELOG.md has release section with date
- [x] README.md version reference updated
- [x] All CI checks pass (1081 tests, clippy, fmt)
- [ ] Ready for tagging after merge