### PR TITLE
release: v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-07-07
+
 ### Security
 
-- Update `quick-xml` to 0.41.0 to address RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader` enabling memory-exhaustion DoS)
-- Update `ammonia` to 4.1.3 to address an mXSS bypass via MathML `annotation-xml` encoding strip
-- Update `crossbeam-epoch` (dev dependency, via `criterion`) to 0.9.20 to address RUSTSEC-2026-0204
+- Update `quick-xml` to 0.41.0 to address RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader` enabling memory-exhaustion DoS) (#408)
+- Update `ammonia` to 4.1.3 to address an mXSS bypass via MathML `annotation-xml` encoding strip (#408)
+- Update `crossbeam-epoch` (dev dependency, via `criterion`) to 0.9.20 to address RUSTSEC-2026-0204 (#408)
+
+### Changed
+
+- Bump `pyo3` from 0.28.3 to 0.29.0 (#395)
+- Bump `napi` from 3.9.0 to 3.10.3 across the patch- and minor-updates groups (#398, #400, #402, #406)
+- Bump `napi-derive` from 3.5.6 to 3.5.9 (#402, #409)
+- Bump `chrono` in the patch-updates group (#394)
+- Bump `reqwest`, `compact_str`, and `memchr` in the patch-updates group (#392)
+- Bump `memchr`, `regex`, and `napi-sys` in the patch-updates group (#398)
+- Bump `anyhow` in the patch-updates group (#402)
+- Bump `html-escape` in the patch-updates group (#409)
+- Bump `@biomejs/biome` and `@napi-rs/cli` (Node.js dev tooling) (#391, #397, #401, #404)
+- Bump `lewagon/wait-on-check-action` from 1.7.0 to 1.8.1 (#396, #403)
+- Bump `actions/checkout` from 6 to 7 (#399)
+- Bump `codecov/codecov-action` from 6 to 7 (#393)
 
 ## [0.5.4] - 2026-05-26
 
@@ -498,7 +515,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage
 - Documentation with examples
 
-[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/bug-ops/feedparser-rs/compare/v0.5.1...v0.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "feedparser-rs"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "ammonia",
  "chrono",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-node"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "feedparser-rs",
  "napi",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "feedparser-rs-py"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "feedparser-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["bug-ops"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-feedparser-rs = "0.5.4"
+feedparser-rs = "0.5.5"
 ```
 
 > [!IMPORTANT]

--- a/crates/feedparser-rs-node/package.json
+++ b/crates/feedparser-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedparser-rs",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "High-performance RSS/Atom/JSON Feed parser for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/feedparser-rs-py/pyproject.toml
+++ b/crates/feedparser-rs-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "feedparser-rs"
-version = "0.5.4"
+version = "0.5.5"
 description = "High-performance RSS/Atom/JSON Feed parser with feedparser-compatible API"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump version from 0.5.4 to 0.5.5
- Update CHANGELOG.md with release notes: RUSTSEC-2026-0195/0204 security fixes (#408) plus all dependency bumps merged since v0.5.4
- Refresh README.md and package manifests (pyproject.toml, package.json) with the new version

## Checklist

- [x] Version updated in all manifests (Cargo.toml workspace.package, pyproject.toml, package.json)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass locally (fmt, clippy, nextest, rustdoc gate, doctests, release build)
- [x] MSRV 1.88.0 verified
- [ ] Ready for tagging after merge