### PR TITLE
docs: fix inaccurate API references across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To disable HTTP support and reduce dependencies:
 
 ```toml
 [dependencies]
-feedparser-rs = { version = "0.5.0", default-features = false }
+feedparser-rs = { version = "0.5", default-features = false }
 ```
 
 ## Workspace Structure

--- a/README.md
+++ b/README.md
@@ -122,17 +122,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #### Fetching from URL
 
 ```rust
-use feedparser_rs::fetch_and_parse;
+use feedparser_rs::parse_url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let feed = fetch_and_parse("https://example.com/feed.xml")?;
+    let feed = parse_url("https://example.com/feed.xml", None, None, None)?;
     println!("Fetched {} entries", feed.entries.len());
     Ok(())
 }
 ```
 
 > [!TIP]
-> Use `fetch_and_parse` for URL fetching with automatic compression handling (gzip, deflate, brotli).
+> Use `parse_url` for URL fetching with automatic compression handling (gzip, deflate, brotli) and conditional GET via the `etag`/`modified` parameters.
 
 ### Python
 
@@ -163,7 +163,7 @@ print(d.channel.title)     # -> d.feed.title
 ### Node.js
 
 ```javascript
-import { parse, fetchAndParse } from 'feedparser-rs';
+import { parse, parseUrl } from 'feedparser-rs';
 
 // Parse from string
 const feed = parse('<rss version="2.0">...</rss>');
@@ -171,8 +171,8 @@ console.log(feed.version);  // 'rss20'
 console.log(feed.feed.title);
 console.log(feed.entries.length);
 
-// Fetch from URL
-const remoteFeed = await fetchAndParse('https://example.com/feed.xml');
+// Fetch from URL (synchronous)
+const remoteFeed = parseUrl('https://example.com/feed.xml');
 ```
 
 See [Node.js API documentation](crates/feedparser-rs-node/README.md) for complete reference.

--- a/crates/feedparser-rs-core/README.md
+++ b/crates/feedparser-rs-core/README.md
@@ -92,7 +92,7 @@ To disable HTTP support and reduce dependencies:
 
 ```toml
 [dependencies]
-feedparser-rs = { version = "0.4", default-features = false }
+feedparser-rs = { version = "0.5", default-features = false }
 ```
 
 ## Cargo Features

--- a/crates/feedparser-rs-node/README.md
+++ b/crates/feedparser-rs-node/README.md
@@ -57,14 +57,22 @@ console.log(feed.version);  // "rss20"
 Fetch and parse feeds directly from URLs:
 
 ```javascript
-import { fetchAndParse } from 'feedparser-rs';
+import { parseUrl } from 'feedparser-rs';
 
-const feed = await fetchAndParse('https://example.com/feed.xml');
+const feed = parseUrl('https://example.com/feed.xml');
 console.log(feed.feed.title);
 console.log(`Fetched ${feed.entries.length} entries`);
+
+// Subsequent fetch with conditional GET (uses ETag/Last-Modified)
+const feed2 = parseUrl('https://example.com/feed.xml', feed.etag, feed.modified);
+if (feed2.status === 304) {
+  console.log('Not modified, use cached version');
+}
 ```
 
-> **Tip:** `fetchAndParse` automatically handles compression (gzip, deflate, brotli) and follows redirects.
+> **Important:** `parseUrl` is synchronous — it blocks the event loop for the duration of the HTTP request. Run it inside a worker thread if you need to avoid blocking on slow feeds.
+
+> **Tip:** `parseUrl` automatically handles compression (gzip, deflate, brotli) and follows redirects.
 
 ### Parsing from Buffer
 
@@ -78,30 +86,45 @@ const feed = parse(buffer);
 
 ## API
 
-### `parse(source: Buffer | string | Uint8Array): ParsedFeed`
+### `parse(source: Buffer | string): ParsedFeed`
 
 Parse a feed from bytes or string.
 
 **Parameters:**
-- `source` - Feed content as Buffer, string, or Uint8Array
+- `source` - Feed content as Buffer or string
 
 **Returns:**
 - `ParsedFeed` object with feed metadata and entries
 
 **Throws:**
-- `Error` if parsing fails catastrophically
+- `Error` if the input exceeds the size limit or parsing fails catastrophically
 
-### `fetchAndParse(url: string): Promise<ParsedFeed>`
+### `parseWithOptions(source: Buffer | string, maxSize?: number): ParsedFeed`
 
-Fetch and parse a feed from URL.
+Like `parse`, with a custom maximum feed size in bytes (default: 100 MB). Guards against
+DoS via oversized input.
+
+### `parseUrl(url: string, etag?: string, modified?: string, userAgent?: string): ParsedFeed`
+
+Fetch and parse a feed from an HTTP/HTTPS URL, with conditional GET support. **Synchronous**
+— blocks the event loop for the duration of the request.
 
 **Parameters:**
 - `url` - Feed URL to fetch
+- `etag` - ETag from a previous fetch, for conditional GET
+- `modified` - Last-Modified value from a previous fetch, for conditional GET
+- `userAgent` - Custom `User-Agent` header
 
 **Returns:**
-- Promise resolving to `ParsedFeed` object
+- `ParsedFeed` object with HTTP metadata (`status`, `href`, `etag`, `modified`, `headers`) populated. On a `304 Not Modified` response, `entries` is empty and `status` is `304`.
 
-### `detectFormat(source: Buffer | string | Uint8Array): string`
+> **Note:** Only available when the `http` Cargo feature is enabled (the default for the published npm package).
+
+### `parseUrlWithOptions(url: string, etag?: string, modified?: string, userAgent?: string, maxSize?: number): ParsedFeed`
+
+Like `parseUrl`, with a custom maximum feed size in bytes.
+
+### `detectFormat(source: Buffer | string): string`
 
 Detect feed format without full parsing.
 
@@ -115,6 +138,8 @@ console.log(format);  // "atom10"
 
 ## Types
 
+> **Note:** Field names follow napi-rs's automatic snake_case → camelCase conversion. Fields below are a representative subset — see `index.d.ts` for the complete definitions, including `Link`, `Person`, `Tag`, `Image`, `Enclosure`, `Itunes*`, `Podcast*`, `Media*`, and Dublin Core/GeoRSS fields.
+
 ### ParsedFeed
 
 ```typescript
@@ -122,30 +147,45 @@ interface ParsedFeed {
   feed: FeedMeta;
   entries: Entry[];
   bozo: boolean;
-  bozo_exception?: string;
+  bozoException?: string;
   encoding: string;
   version: string;
   namespaces: Record<string, string>;
+  status?: number;                   // HTTP status code (parseUrl only)
+  href?: string;                      // Final URL after redirects (parseUrl only)
+  etag?: string;                      // For conditional GET (parseUrl only)
+  modified?: string;                  // Last-Modified header (parseUrl only)
+  headers?: Record<string, string>;   // Full response headers (parseUrl only)
 }
 ```
 
 ### FeedMeta
 
+Dates are exposed as a raw string (original value, timezone preserved) plus a `*Parsed`
+variant with milliseconds since epoch.
+
 ```typescript
 interface FeedMeta {
   title?: string;
-  title_detail?: TextConstruct;
+  titleDetail?: TextConstruct;
   link?: string;
   links: Link[];
   subtitle?: string;
-  updated?: number;  // Milliseconds since epoch
+  updated?: string;          // Raw date string
+  updatedParsed?: number;    // Milliseconds since epoch
+  published?: string;
+  publishedParsed?: number;
   author?: string;
   authors: Person[];
   language?: string;
   image?: Image;
   tags: Tag[];
   id?: string;
-  ttl?: number;
+  ttl?: string;               // Kept as string for feedparser compatibility
+  itunes?: ItunesFeedMeta;
+  podcast?: PodcastMeta;
+  // ...and more: subtitleDetail, summary, contributors, publisher, rights,
+  // generator, icon, logo, syndication, media*, cloud, textinput, etc.
 }
 ```
 
@@ -159,17 +199,23 @@ interface Entry {
   links: Link[];
   summary?: string;
   content: Content[];
-  published?: number;  // Milliseconds since epoch
-  updated?: number;
+  published?: string;         // Raw date string
+  publishedParsed?: number;   // Milliseconds since epoch
+  updated?: string;
+  updatedParsed?: number;
   author?: string;
   authors: Person[];
   tags: Tag[];
   enclosures: Enclosure[];
-  media_title?: string;
+  mediaTitle?: string;
+  itunes?: ItunesEntryMeta;   // Episode duration, explicit, image, episode/season number
+  podcast?: PodcastEntryMeta; // Podcast 2.0: transcripts, chapters, soundbites, persons
+  // ...and more: titleDetail, subtitleDetail, rights, created*, expired*,
+  // publisher, contributors, comments, source, media*, thr*, dc*, etc.
 }
 ```
 
-> **Note:** See `index.d.ts` for complete type definitions including `Link`, `Person`, `Tag`, `Image`, `Enclosure`, and more.
+> **Note:** See `index.d.ts` for complete type definitions.
 
 ## Error Handling
 
@@ -179,7 +225,7 @@ The library uses a "bozo" flag (like feedparser) to indicate parsing errors whil
 const feed = parse('<rss><channel><title>Broken</title></rss>');
 
 if (feed.bozo) {
-  console.warn('Feed has errors:', feed.bozo_exception);
+  console.warn('Feed has errors:', feed.bozoException);
 }
 
 // Still can access parsed data
@@ -188,12 +234,14 @@ console.log(feed.feed.title);  // "Broken"
 
 ## Dates
 
-All date fields are returned as milliseconds since Unix epoch. Convert to JavaScript Date:
+Each date field is exposed twice: the raw string as it appeared in the feed (timezone
+preserved) and a `*Parsed` variant with milliseconds since Unix epoch, ready for `Date`:
 
 ```javascript
 const entry = feed.entries[0];
-if (entry.published) {
-  const date = new Date(entry.published);
+console.log(entry.published);        // e.g. "Mon, 06 Jul 2026 10:00:00 -0800" (raw string)
+if (entry.publishedParsed) {
+  const date = new Date(entry.publishedParsed);
   console.log(date.toISOString());
 }
 ```
@@ -227,7 +275,7 @@ Pre-built binaries available for:
 | Linux | x64, arm64 |
 | Windows | x64 |
 
-Supported Node.js versions: 18, 20, 22+
+Minimum Node.js version: 18 (per `package.json` `engines`). CI tests run on Node.js 22 and 24.
 
 ## Development
 

--- a/crates/feedparser-rs-py/README.md
+++ b/crates/feedparser-rs-py/README.md
@@ -155,7 +155,7 @@ if d.feed.itunes:
 # Episode metadata
 for entry in d.entries:
     if entry.itunes:
-        print(f"Duration: {entry.itunes.duration}s")
+        print(f"Duration: {entry.itunes.duration}")  # e.g. "01:30:00"
 ```
 
 ## API Reference


### PR DESCRIPTION
## Summary

Audited all four READMEs (root + three crate-level) against the actual source to catch documentation drift. Found and fixed real correctness bugs, not just cosmetic refresh:

- **Root README** and **Node.js binding README**: the Rust and Node.js "Fetching from URL" examples called a nonexistent `feedparser_rs::fetch_and_parse` / `fetchAndParse`. The real functions are `parse_url` (Rust) and `parseUrl` (Node.js, synchronous — not `async`/`Promise`).
- **Node.js binding README**: rewrote the HTTP fetching section, API reference, and Types section to match `crates/feedparser-rs-node/src/lib.rs`:
  - `bozo_exception` is exposed as `bozoException` (napi camelCase conversion)
  - date fields are exposed as a raw string plus a separate `*Parsed` field in milliseconds, not a single numeric field as previously documented
  - added `parseWithOptions`/`parseUrlWithOptions`, the HTTP-only `ParsedFeed` fields (`status`/`href`/`etag`/`modified`/`headers`), and `itunes`/`podcast` fields
  - corrected the supported Node.js versions claim to match what CI actually tests (22, 24) vs. the `package.json` `engines` minimum (18)
- **Python binding README**: fixed the `entry.itunes.duration` example, which implied a numeric seconds value with an `"s"` suffix appended; the field is actually a raw string like `"01:30:00"`.
- **Core crate README**: bumped a stale `"0.4"` version pin in the disable-default-features example to match the crate's current `0.5` line.

## Test plan

- [x] Cross-checked every documented function name, parameter list, and struct field against the actual Rust/napi/PyO3 source (`src/lib.rs`, `src/types/*`) via independent read-only audits per crate
- [x] Confirmed no remaining references to the nonexistent `fetch_and_parse`/`fetchAndParse` anywhere in the repo
- [x] Rebased onto `main` post-v0.5.5 release so version references are current