### PR TITLE
fix(deps): bump quinn-proto to 0.11.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `brace-expansion` to 5.0.8 and `js-yaml` to 4.3.0 (transitive Node.js dev dependencies) to address high-severity `npm audit` advisories (DoS via numeric-range expansion and YAML merge-key chains)
 - Update `ammonia` to 4.1.4 to address RUSTSEC-2026-0213 (XSS via SVG `animate`/`set` animation tags with `javascript:` scheme)
+- Update `quinn-proto` (transitive, via `reqwest`) to 0.11.15 to address RUSTSEC-2026-0185/GHSA-4w2j-m93h-cj5j (remote memory exhaustion from unbounded out-of-order stream reassembly)
 
 ## [0.5.5] - 2026-07-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- Bumps `quinn-proto` (transitive dependency via `reqwest`) from 0.11.14 to 0.11.15
- Addresses GHSA-4w2j-m93h-cj5j / RUSTSEC-2026-0185: unbounded out-of-order stream reassembly could allow remote memory exhaustion
- Resolves Dependabot alert #30

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace --exclude feedparser-rs-py -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --exclude feedparser-rs-py` (1081 passed)